### PR TITLE
Bug/version code quotes

### DIFF
--- a/Sources/VariantsCore/Factory/android/GradleScriptFactory.swift
+++ b/Sources/VariantsCore/Factory/android/GradleScriptFactory.swift
@@ -197,7 +197,7 @@ fileprivate extension String {
         self.appendLine("rootProject.ext.\(name) = \"\(value.envVarValue() ?? value)\"")
     }
     
-    // This will add the value without parenthesis
+    // This will add the value without quotes
     // This is useful in cases of versionCode which should be
     // represented as an int and not a string.
     mutating func addGradleValueDefinition(_ name: String, value: String) {


### PR DESCRIPTION
… that they can be read as an integer and not a string

### What does this PR do
 - This fixes a problem where versionCode was being stored as a string value as opposed to an integer. This was causing the Android build to fail.

### How can it be tested
 - Go into sample android project. Run `variants init`, configure variants.yml, run `variants setup`. Configure the sample project gradle to read values from `variants.gradle`. Notice in `variants.gradle`, that versionCode value is no longer surrounded in quotes. Build app and notice there is no more build errors.

### Screenshots (if any)


#### Task
resolves #73 

### Checklist:

- [x] I have not introduced new bugs :rofl:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
