### PR TITLE
Add Danger to automate code review chores

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -30,7 +30,7 @@ jobs:
       run: bundle exec slather coverage
 
     - name: Danger
-      run: danger-swift ci
+      run: swift run danger-swift ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Code coverage report
       run: bundle exec slather coverage
 
+    - name: Danger
+      run: danger-swift ci
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -29,11 +29,6 @@ jobs:
     - name: Code coverage report
       run: bundle exec slather coverage
 
-    - name: Danger
-      uses: danger/swift@2.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -30,7 +30,7 @@ jobs:
       run: bundle exec slather coverage
 
     - name: Danger
-      run: swift run danger-swift ci
+      uses: danger/swift@2.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Danger
-        uses: danger/swift@2.0.1
+        uses: danger/swift@3.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -1,0 +1,17 @@
+name: "Danger Swift"
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+    paths:
+      - '**/*.swift'
+
+jobs:
+  danger-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Danger
+        uses: danger/swift@2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable all
 import Danger
 
 fileprivate extension Danger.File {
@@ -65,4 +66,4 @@ if let additions = danger.github?.pullRequest.additions, let deletions = danger.
 if hasSourceChanges && !git.modifiedFiles.contains(where: { $0.isInTests }) {
     warn("The library files were changed, but the tests remained unmodified. Consider updating or adding to the tests to match the library changes.")
 }
-
+// swiftlint:enable all

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,67 @@
+import Danger
+
+fileprivate extension Danger.File {
+    var isInSources: Bool { hasPrefix("Sources/") }
+    var isInTests: Bool { hasPrefix("Tests/") }
+    
+    var isSourceFile: Bool {
+        hasSuffix(".swift") || hasSuffix(".h") || hasSuffix(".m")
+    }
+    
+    var isSwiftPackageDefintion: Bool {
+        hasPrefix("Package") && hasSuffix(".swift")
+    }
+    
+    var isDangerfile: Bool {
+        self == "Dangerfile.swift"
+    }
+}
+
+let danger = Danger()
+let git = danger.git
+
+// Sometimes it's a README fix, or something like that - which isn't relevant for
+// including in a project's CHANGELOG for example
+let isDeclaredTrivial = danger.github?.pullRequest.title.contains("#trivial") ?? false
+let changedFiles = (git.modifiedFiles + git.createdFiles).filter { $0.isInSources || $0.isInTests }
+let hasSourceChanges = (git.modifiedFiles + git.createdFiles).contains { $0.isInSources }
+
+let allSourceFiles = danger.git.modifiedFiles + danger.git.createdFiles
+var bigPRThreshold = 2;
+
+let swiftFilesWithoutCopyright = changedFiles.filter {
+    $0.fileType == .swift
+        && !danger.utils.readFile($0).contains(
+            """
+            //
+            //  Variants
+            //
+            //  Copyright (c) Backbase B.V. - https://www.backbase.com
+            """)
+}
+
+if swiftFilesWithoutCopyright.count > 0 {
+    let files = swiftFilesWithoutCopyright.joined(separator: ", ")
+    fail("Copyright header is missing in files: \(files)")
+}
+
+// Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+if danger.github?.pullRequest.title.contains("WIP") == true {
+    warn("PR is marked as Work in Progress")
+}
+
+// Warn when there is a big PR
+if let additions = danger.github?.pullRequest.additions, let deletions = danger.github?.pullRequest.deletions, additions + deletions > 500 {
+    warn("Pull request is relatively big. If this PR contains multiple changes, consider splitting it into separate PRs for easier reviews.")
+}
+
+// Changelog entries are required for changes to library files.
+if hasSourceChanges && !isDeclaredTrivial && !git.modifiedFiles.contains("CHANGELOG.md") {
+    warn("Any changes to library code should be reflected in the CHANGELOG. Please consider adding a note there about your change.")
+}
+
+// Warn when library files has been updated but not tests.
+if hasSourceChanges && !git.modifiedFiles.contains(where: { $0.isInTests }) {
+    warn("The library files were changed, but the tests remained unmodified. Consider updating or adding to the tests to match the library changes.")
+}
+

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable all
 import Danger
 
 fileprivate extension Danger.File {
@@ -28,7 +27,7 @@ let changedFiles = (git.modifiedFiles + git.createdFiles).filter { $0.isInSource
 let hasSourceChanges = (git.modifiedFiles + git.createdFiles).contains { $0.isInSources }
 
 let allSourceFiles = danger.git.modifiedFiles + danger.git.createdFiles
-var bigPRThreshold = 500;
+var bigPRThreshold = 500
 
 let swiftFilesWithoutCopyright = changedFiles.filter {
     $0.fileType == .swift
@@ -52,8 +51,12 @@ if danger.github?.pullRequest.title.contains("WIP") == true {
 }
 
 // Warn when there is a big PR
-if let additions = danger.github?.pullRequest.additions, let deletions = danger.github?.pullRequest.deletions, additions + deletions > bigPRThreshold {
-    warn("Pull request is relatively big. If this PR contains multiple changes, consider splitting it into separate PRs for easier reviews.")
+if let additions = danger.github?.pullRequest.additions,
+   let deletions = danger.github?.pullRequest.deletions, additions + deletions > bigPRThreshold {
+    warn("""
+        Pull request is relatively big. If this PR contains multiple changes,
+        consider splitting it into separate PRs for easier reviews.
+        """)
 }
 
 // Changelog entries are required for changes to library files.
@@ -64,6 +67,8 @@ if let additions = danger.github?.pullRequest.additions, let deletions = danger.
 
 // Warn when library files has been updated but not tests.
 if hasSourceChanges && !git.modifiedFiles.contains(where: { $0.isInTests }) {
-    warn("The library files were changed, but the tests remained unmodified. Consider updating or adding to the tests to match the library changes.")
+    warn("""
+        The library files were changed, but the tests remained unmodified.
+        Consider updating or adding to the tests to match the library changes.
+        """)
 }
-// swiftlint:enable all

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -56,9 +56,10 @@ if let additions = danger.github?.pullRequest.additions, let deletions = danger.
 }
 
 // Changelog entries are required for changes to library files.
-if hasSourceChanges && !isDeclaredTrivial && !git.modifiedFiles.contains("CHANGELOG.md") {
-    warn("Any changes to library code should be reflected in the CHANGELOG. Please consider adding a note there about your change.")
-}
+// TODO: Enabled prior to 1.0.0 release
+//if hasSourceChanges && !isDeclaredTrivial && !git.modifiedFiles.contains("CHANGELOG.md") {
+//    warn("Any changes to library code should be reflected in the CHANGELOG. Please consider adding a note there about your change.")
+//}
 
 // Warn when library files has been updated but not tests.
 if hasSourceChanges && !git.modifiedFiles.contains(where: { $0.isInTests }) {

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -27,7 +27,7 @@ let changedFiles = (git.modifiedFiles + git.createdFiles).filter { $0.isInSource
 let hasSourceChanges = (git.modifiedFiles + git.createdFiles).contains { $0.isInSources }
 
 let allSourceFiles = danger.git.modifiedFiles + danger.git.createdFiles
-var bigPRThreshold = 2;
+var bigPRThreshold = 500;
 
 let swiftFilesWithoutCopyright = changedFiles.filter {
     $0.fileType == .swift
@@ -51,7 +51,7 @@ if danger.github?.pullRequest.title.contains("WIP") == true {
 }
 
 // Warn when there is a big PR
-if let additions = danger.github?.pullRequest.additions, let deletions = danger.github?.pullRequest.deletions, additions + deletions > 500 {
+if let additions = danger.github?.pullRequest.additions, let deletions = danger.github?.pullRequest.deletions, additions + deletions > bigPRThreshold {
     warn("Pull request is relatively big. If this PR contains multiple changes, consider splitting it into separate PRs for easier reviews.")
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
             name: "Variants",
             dependencies: [
                 "VariantsCore",
-                .product(name: "Danger", package: "danger-swift"),
+                .product(name: "Danger", package: "danger-swift")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,11 @@ let package = Package(
         .package(
             url: "https://github.com/stencilproject/Stencil.git",
             from: "0.13.0"
+        ),
+        .package(
+            name: "danger-swift",
+            url: "https://github.com/danger/swift.git",
+            from: "3.5.0"
         )
     ],
     targets: [
@@ -44,7 +49,8 @@ let package = Package(
         .target(
             name: "Variants",
             dependencies: [
-                "VariantsCore"
+                "VariantsCore",
+                .product(name: "Danger", package: "danger-swift"),
             ]
         ),
         .testTarget(

--- a/Sources/VariantsCore/Helpers/Bash.swift
+++ b/Sources/VariantsCore/Helpers/Bash.swift
@@ -1,5 +1,8 @@
 //
-// Copyright © 2020 Backbase R&D B.V. All rights reserved.
+//  Variants
+//
+//  Copyright (c) Backbase B.V. - https://www.backbase.com
+//  Created by Balazs Toth
 //
 
 import Foundation

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import VariantsTests
-
-var tests = [XCTestCaseEntry]()
-tests += VariantsTests.allTests()
-XCTMain(tests)

--- a/Tests/VariantsTests/VariantsTests.swift
+++ b/Tests/VariantsTests/VariantsTests.swift
@@ -1,3 +1,10 @@
+//
+//  Variants
+//
+//  Copyright (c) Backbase B.V. - https://www.backbase.com
+//  Created by Arthur Alves
+//
+
 import XCTest
 import class Foundation.Bundle
 

--- a/Tests/VariantsTests/XCTestManifests.swift
+++ b/Tests/VariantsTests/XCTestManifests.swift
@@ -1,3 +1,10 @@
+//
+//  Variants
+//
+//  Copyright (c) Backbase B.V. - https://www.backbase.com
+//  Created by Arthur Alves
+//
+
 import XCTest
 
 #if !canImport(ObjectiveC)


### PR DESCRIPTION
### What does this PR do
- Adds [Danger](https://danger.systems/swift/) to automate common code review chores.

### How can it be tested
- Run locally, `swift run danger-swift local`.

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
