### PR TITLE
Attempt to integrate Danger comments directly in PRs

### DIFF
--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -3,8 +3,6 @@ name: "Danger Swift"
 on:
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - '**/*.swift'
 
 jobs:
   danger-scan:

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -15,3 +15,4 @@ jobs:
         uses: danger/swift@3.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -3,10 +3,6 @@ name: SwiftLint
 on:
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
 
 jobs:
   SwiftLint:


### PR DESCRIPTION
### What does this PR do
- Add `DANGER_GITHUB_API_TOKEN` as environment variable to Danger, so that @backbaseoss can post comments on Danger's behalf.

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
