### PR TITLE
Create gradle script even when skipFastlane is set to true

### DIFF
--- a/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
@@ -30,7 +30,7 @@ class AndroidProject: Project {
             throw RuntimeError("Unable to load spec '\(spec)'")
         }
 
-        createVariants(with: configuration, spec: spec)
+        try createVariants(with: configuration, spec: spec)
         setupFastlane(with: configuration, skip: skipFastlane)
     }
 
@@ -88,7 +88,13 @@ class AndroidProject: Project {
         try storeFastlaneParams(customProperties, configuration: configuration)
     }
 
-    private func createVariants(with configuration: AndroidConfiguration, spec: String) {}
+    private func createVariants(with configuration: AndroidConfiguration, spec: String) throws {
+        guard let defaultVariant = configuration.variants
+                .first(where: { $0.name.lowercased() == "default" }) else {
+            throw ValidationError("Variant 'default' not found.")
+        }
+        try gradleFactory.createScript(with: configuration, variant: defaultVariant)
+    }
 
     // swiftlint:disable function_body_length
     private func setupFastlane(with configuration: AndroidConfiguration, skip: Bool) {
@@ -131,7 +137,6 @@ class AndroidProject: Project {
                             .first(where: { $0.name.lowercased() == "default" }) else {
                         throw ValidationError("Variant 'default' not found.")
                     }
-                    try gradleFactory.createScript(with: configuration, variant: defaultVariant)
                     
                     var customProperties: [CustomProperty] = (defaultVariant.custom ?? []) + (configuration.custom ?? [])
                     customProperties.append(defaultVariant.destinationProperty)

--- a/Tests/VariantsCoreTests/AndroidProjectTests.swift
+++ b/Tests/VariantsCoreTests/AndroidProjectTests.swift
@@ -56,10 +56,10 @@ class AndroidProjectTests: XCTestCase {
         if let spec = specPath() {
             XCTAssertNoThrow(try project.setup(spec: spec.string, skipFastlane: true, verbose: true))
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.count, 0)
-            XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 0)
+            XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 1)
 
             XCTAssertNoThrow(try project.setup(spec: spec.string, skipFastlane: false, verbose: true))
-            XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 1)
+            XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 2)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.first?.variant.name, "default")
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.count, 1)
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.folder.string, "fastlane/parameters/")


### PR DESCRIPTION
### What does this PR do
- Creates gradle script even when `skipFastlane` is set to true

### How can it be tested
Running `make validation` and `swift run danger-swift local` should not return any error

### Task
resolves #93 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
