### PR TITLE
Populate package name in 'variants_params.rb'

### DIFF
--- a/Sources/VariantsCore/Helpers/Constants.swift
+++ b/Sources/VariantsCore/Helpers/Constants.swift
@@ -8,7 +8,9 @@
 import Foundation
 import PathKit
 
-struct Constants {}
+struct Constants {
+    static let packageNameKey = "PACKAGE_NAME"
+}
 
 struct StaticPath {
     struct Fastlane {

--- a/Tests/VariantsCoreTests/AndroidProjectTests.swift
+++ b/Tests/VariantsCoreTests/AndroidProjectTests.swift
@@ -62,11 +62,21 @@ class AndroidProjectTests: XCTestCase {
             XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 2)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.first?.variant.name, "default")
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.count, 1)
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.folder.string, "fastlane/parameters/")
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.count, 3)
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.first?.name, "SAMPLE_PROJECT")
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.first?.value, "Sample Project Default Config")
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.first?.destination, .project)
+            
+            let fastlaneFactoryLastRequest = fastlaneFactoryMock.createParametersCache.last
+            XCTAssertEqual(fastlaneFactoryLastRequest?.folder.string, "fastlane/parameters/")
+            XCTAssertEqual(fastlaneFactoryLastRequest?.parameters.count, 4)
+            XCTAssertEqual(fastlaneFactoryLastRequest?.parameters.first?.name, "SAMPLE_PROJECT")
+            XCTAssertEqual(fastlaneFactoryLastRequest?.parameters.first?.value, "Sample Project Default Config")
+            XCTAssertEqual(fastlaneFactoryLastRequest?.parameters.first?.destination, .project)
+            
+            let packageProperty = fastlaneFactoryMock.createParametersCache
+                .last?.parameters.first(where: { $0.name == "PACKAGE_NAME" })
+            XCTAssertNotNil(packageProperty)
+            if let packageProperty = packageProperty {
+                XCTAssertEqual(packageProperty.value, "com.backbase.frank")
+                XCTAssertEqual(packageProperty.destination, .fastlane)
+            }
         }
     }
     
@@ -112,14 +122,14 @@ class AndroidProjectTests: XCTestCase {
             let testVariant = "test"
             XCTAssertNoThrow(try project.switch(to: testVariant, spec: spec.string, verbose: true))
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.count, 1)
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.first?.parameters.count, 4)
+            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.first?.parameters.count, 5)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 1)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.first?.variant.name, "test")
 
             let defaultVariant = "default"
             XCTAssertNoThrow(try project.switch(to: defaultVariant, spec: spec.string, verbose: true))
             XCTAssertEqual(fastlaneFactoryMock.createParametersCache.count, 2)
-            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.count, 3)
+            XCTAssertEqual(fastlaneFactoryMock.createParametersCache.last?.parameters.count, 4)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.count, 2)
             XCTAssertEqual(gradleFactoryMock.createScriptCache.last?.variant.name, "default")
         }


### PR DESCRIPTION
### What does this PR do
- Directly populate `fastlane/parameters/variants_params.rb` with `"PACKAGE_NAME"` so that Fastlane can use when deploying to PlayStore.

### How can it be tested
- Running `variants setup` or `variants switch` for an Android project should result in `variants_params.rb` containing the property `"PACKAGE_NAME"`.

### Task
resolves #80 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
