### PR TITLE
Feat/110 test host

### DIFF
--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -140,6 +140,14 @@ class XCConfigFactory: XCFactory {
                 in: projectPath,
                 target: target.value)
             
+            xcodeFactory.modify(
+                [
+                    "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/$(V_APP_NAME).app/$(V_APP_NAME)"
+                ],
+                in: projectPath,
+                target: target.value,
+                asTestSettings: true)
+            
         } catch {
             logger.logError("❌ ", item: "Failed to add Variants.swift to Xcode Project")
         }

--- a/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
@@ -13,14 +13,16 @@ public typealias NamedTarget = (key: String, value: iOSTarget)
 
 public struct iOSTarget: Codable {
     let name: String
-    let bundleId: String
     let app_icon: String
+    let bundleId: String
+    let testTarget: String
     let source: iOSSource
     
     enum CodingKeys: String, CodingKey {
         case name
         case app_icon
         case bundleId = "bundle_id"
+        case testTarget = "test_target"
         case source
     }
 }

--- a/Templates/ios/variants-template.yml
+++ b/Templates/ios/variants-template.yml
@@ -9,6 +9,7 @@ ios:
       {{ TARGET }}:
         name: {{ APP_NAME }}
         bundle_id: {{ APP_BUNDLE_ID }}
+        test_target: {{ TEST_TARGET }}
         app_icon: {{ APP_ICON }}
         source:
           path: {{ SOURCE }}

--- a/Tests/VariantsCoreTests/Resources/invalid_variants.yml
+++ b/Tests/VariantsCoreTests/Resources/invalid_variants.yml
@@ -71,6 +71,7 @@ ios:
       FrankBank:
         name: FrankBank
         bundle_id: com.backbase.frank.ios
+        test_target: FrankBankTests
         app_icon: AppIcon
         source:
           path: Sources

--- a/Tests/VariantsCoreTests/Resources/ios/invalid_missing_export_method.yml
+++ b/Tests/VariantsCoreTests/Resources/ios/invalid_missing_export_method.yml
@@ -8,6 +8,7 @@ ios:
       FrankBank:
         name: FrankBank
         bundle_id: com.backbase.frank.ios
+        test_target: FrankBankTests
         app_icon: AppIcon
         source:
           path: Sources

--- a/Tests/VariantsCoreTests/Resources/ios/invalid_missing_signing_configuration.yml
+++ b/Tests/VariantsCoreTests/Resources/ios/invalid_missing_signing_configuration.yml
@@ -8,6 +8,7 @@ ios:
       FrankBank:
         name: FrankBank
         bundle_id: com.backbase.frank.ios
+        test_target: FrankBankTests
         app_icon: AppIcon
         source:
           path: Sources

--- a/Tests/VariantsCoreTests/Resources/valid_variants.yml
+++ b/Tests/VariantsCoreTests/Resources/valid_variants.yml
@@ -70,6 +70,7 @@ ios:
       FrankBank:
         name: FrankBank
         bundle_id: com.backbase.frank.ios
+        test_target: FrankBankTests
         app_icon: AppIcon
         source:
           path: Sources

--- a/Tests/VariantsCoreTests/Resources/variants-template.yml
+++ b/Tests/VariantsCoreTests/Resources/variants-template.yml
@@ -9,6 +9,7 @@ ios:
       {{ TARGET }}:
         name: {{ APP_NAME }}
         bundle_id: {{ APP_BUNDLE_ID }}
+        test_target: {{ TEST_TARGET }}
         app_icon: {{ APP_ICON }}
         source:
           path: {{ SOURCE }}

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -100,8 +100,12 @@ class YamlParserTests: XCTestCase {
             let source = iOSSource(path: "sourcePath", info: "sourceInfo", config: "sourceConfig")
             let firstVariant = configuration.ios?.variants.first(where: { $0.name == "default" })
             XCTAssertNotNil(firstVariant)
-            let firstVariantDefaultValues = firstVariant?.getDefaultValues(for:
-                iOSTarget(name: "FrankBank", bundleId: "com.backbase.frank.ios", app_icon: "AppIcon", source: source)
+            let firstVariantDefaultValues = firstVariant?
+                .getDefaultValues(for:iOSTarget(name: "FrankBank",
+                                                app_icon: "AppIcon",
+                                                bundleId: "com.backbase.frank.ios",
+                                                testTarget: "FrankBankTests",
+                                                source: source)
             )
             XCTAssertEqual(firstVariantDefaultValues?["V_VERSION_NUMBER"], "1")
             XCTAssertEqual(firstVariantDefaultValues?["V_APP_NAME"], "FrankBank")

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -100,12 +100,9 @@ class YamlParserTests: XCTestCase {
             let source = iOSSource(path: "sourcePath", info: "sourceInfo", config: "sourceConfig")
             let firstVariant = configuration.ios?.variants.first(where: { $0.name == "default" })
             XCTAssertNotNil(firstVariant)
-            let firstVariantDefaultValues = firstVariant?
-                .getDefaultValues(for:iOSTarget(name: "FrankBank",
-                                                app_icon: "AppIcon",
-                                                bundleId: "com.backbase.frank.ios",
-                                                testTarget: "FrankBankTests",
-                                                source: source)
+            let firstVariantDefaultValues = firstVariant?.getDefaultValues(for:
+                    iOSTarget(name: "FrankBank", app_icon: "AppIcon", bundleId: "com.backbase.frank.ios",
+                              testTarget: "FrankBankTests", source: source)
             )
             XCTAssertEqual(firstVariantDefaultValues?["V_VERSION_NUMBER"], "1")
             XCTAssertEqual(firstVariantDefaultValues?["V_APP_NAME"], "FrankBank")

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -59,6 +59,7 @@ ios:
       SampleProject:
         name: SampleApp
         bundle_id: com.sample.app
+        test_target: SampleProjectTests
         app_icon: AppIcon
         source:
           path: Sources


### PR DESCRIPTION
### What does this PR do
- Adds property for `test_target` for iOS projects in `variants.yml`
- Automatically modifies TEST_HOST to contain dynamic app name

### Task
resolves #110 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
