### PR TITLE
feat: automatically populate 'PROVISIONING_PROFILE_SPECIFIER' if using match in signing configuration

### DIFF
--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -139,8 +139,8 @@ class XCConfigFactory: XCFactory {
             ]
             
             if
-                let _ = variant.signing?.matchURL,
-                let _ = variant.signing?.exportMethod {
+                variant.signing?.matchURL != nil,
+                variant.signing?.exportMethod != nil {
                 mainTargetSettings["PROVISIONING_PROFILE_SPECIFIER"] = "$(V_MATCH_PROFILE)"
             }
             

--- a/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
@@ -29,6 +29,19 @@ extension iOSSigning {
         case development
         case adhoc
         case enterprise
+        
+        var prefix: String {
+            switch self {
+            case .development:
+                return "match Development"
+            case .adhoc:
+                return "match AdHoc"
+            case .appstore:
+                return "match AppStore"
+            case .enterprise:
+                return "match InHouse"
+            }
+        }
     }
 }
 

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -31,7 +31,7 @@ public struct iOSVariant: Codable {
         ]
        
         if
-            let _ = signing?.matchURL,
+            signing?.matchURL != nil,
             let exportMethod = signing?.exportMethod {
             customDictionary["V_MATCH_PROFILE"] = exportMethod.prefix+" "+bundleId
         }

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -20,14 +20,22 @@ public struct iOSVariant: Codable {
     internal let store_destination: String?
     
     func getDefaultValues(for target: iOSTarget) -> [String: String] {
+        let bundleId = target.bundleId+configIdSuffix
+        
         var customDictionary: [String: String] = [
             "V_APP_NAME": target.name+configName,
-            "V_BUNDLE_ID": target.bundleId+configIdSuffix,
+            "V_BUNDLE_ID": bundleId,
             "V_VERSION_NAME": version_name,
             "V_VERSION_NUMBER": String(version_number),
             "V_APP_ICON": app_icon ?? target.app_icon
         ]
        
+        if
+            let _ = signing?.matchURL,
+            let exportMethod = signing?.exportMethod {
+            customDictionary["V_MATCH_PROFILE"] = exportMethod.prefix+" "+bundleId
+        }
+        
         custom?
             .filter { $0.destination == .project && !$0.processForEnvironment().isEnvVar }
             .forEach({ config in


### PR DESCRIPTION
### What does this PR do
- Automatically populate 'PROVISIONING_PROFILE_SPECIFIER' if using match in signing configuration

### Task
resolves #117 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
