### PR TITLE
Update nokogiri to 1.11.0 due to vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'slather'
+gem 'nokogiri', '1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,13 @@ GEM
     concurrent-ruby (1.1.7)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     nanaimo (0.3.0)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
     slather (2.5.0)
       CFPropertyList (>= 2.2, < 4)
       activesupport
@@ -41,6 +43,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  nokogiri (= 1.11.0)
   slather
 
 BUNDLED WITH

--- a/Templates/ios/_fastlane/Gemfile
+++ b/Templates/ios/_fastlane/Gemfile
@@ -5,6 +5,7 @@ gem 'cocoapods-art'
 gem 'fastlane'
 gem 'slather'
 gem 'json', '2.3.0'
+gem 'nokogiri', '1.11.0'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Templates/ios/_fastlane/Gemfile.lock
+++ b/Templates/ios/_fastlane/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     method_source (1.0.0)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.0)
     molinillo (0.6.6)
     multi_json (1.14.1)
@@ -195,14 +195,16 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     os (1.1.0)
     plist (3.5.0)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (2.0.5)
+    racc (1.5.2)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -268,6 +270,7 @@ DEPENDENCIES
   fastlane-plugin-xcconfig
   fastlane-plugin-xchtmlreport
   json (= 2.3.0)
+  nokogiri (= 1.11.0)
   slather
 
 BUNDLED WITH


### PR DESCRIPTION
### What does this PR do
- Update `nokogiri` to version 1.11.0 due to [this low severity vulnerability](https://github.com/advisories/GHSA-vr8q-g5c7-m54m)

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
