### PR TITLE
Improve warnings during `variants init`

### DIFF
--- a/Sources/VariantsCore/Helpers/SpecHelper.swift
+++ b/Sources/VariantsCore/Helpers/SpecHelper.swift
@@ -15,12 +15,34 @@ enum iOSProjectKey: String, CaseIterable {
     case target = "TARGET"
     case appName = "APP_NAME"
     case appBundleID = "APP_BUNDLE_ID"
+    case testTarget = "TEST_TARGET"
     case appIcon = "APP_ICON"
     case source = "SOURCE"
     case infoPlist = "INFO_PLIST"
     
     var placeholder: String {
         "{{ "+rawValue+" }}"
+    }
+    
+    var ymlKeyPath: String {
+        switch self {
+        case .project:
+            return "ios.xcodeproj"
+        case .target:
+            return "ios.targets.fooTarget"
+        case .appName:
+            return "ios.targets.fooTarget.name"
+        case .appBundleID:
+            return "ios.targets.fooTarget.bundle_id"
+        case .testTarget:
+            return "ios.targets.fooTarget.test_target"
+        case .appIcon:
+            return "ios.targets.fooTarget.app_icon"
+        case .source:
+            return "ios.targets.fooTarget.source.path"
+        case .infoPlist:
+            return "ios.targets.fooTarget.source.info"
+        }
     }
 }
 
@@ -73,12 +95,31 @@ class iOSSpecHelper: SpecHelper {
                 try Bash("sed", arguments: "-i", "-e", "s/\(key.placeholder)/\(escapedValue)/g", "\(variantsPath)").run()
         }
 
-        if projectSpecificInformation.count < iOSProjectKey.allCases.count {
+        if projectSpecificInformation.isEmpty {
             Logger.shared.logWarning("⚠️  ", item: """
                 We were unable to populate './variants.yml' automatically.
-                Please open the file and remove the placeholders.
+                Please open the file and remove the placeholder values.
+                i.e.: '{{ VALUE }}'
                 """
             )
+        } else if projectSpecificInformation.count < iOSProjectKey.allCases.count {
+            var warningMessage = """
+                We were unable to populate the following fields in the './variants.yml' spec.
+                Please add them manually by replacing the placeholders:
+
+                """
+            
+            iOSProjectKey.allCases
+                .filter { !projectSpecificInformation.keys.contains($0) }
+                .forEach { projectKey in
+                    var ymlKeyPath = projectKey.ymlKeyPath
+                    if let targetName = projectSpecificInformation[.target] {
+                        ymlKeyPath = ymlKeyPath.replacingOccurrences(of: "fooTarget", with: targetName)
+                    }
+                    warningMessage.appendLine("    * "+ymlKeyPath)
+                }
+            
+            Logger.shared.logWarning("⚠️  ", item: warningMessage)
         }
 
         // Remove remaining '*-e' file after `sed` in-file replacemnt

--- a/Sources/VariantsCore/Helpers/SpecHelper.swift
+++ b/Sources/VariantsCore/Helpers/SpecHelper.swift
@@ -104,8 +104,8 @@ class iOSSpecHelper: SpecHelper {
             )
         } else if projectSpecificInformation.count < iOSProjectKey.allCases.count {
             var warningMessage = """
-                We were unable to populate the following fields in the './variants.yml' spec.
-                Please add them manually by replacing the placeholders:
+                We were unable to populate the following fields in the './variants.yml' spec:
+
 
                 """
             
@@ -118,6 +118,8 @@ class iOSSpecHelper: SpecHelper {
                     }
                     warningMessage.appendLine("    * "+ymlKeyPath)
                 }
+            
+            warningMessage.appendLine("\nPlease replace their placeholders manually.")
             
             Logger.shared.logWarning("⚠️  ", item: warningMessage)
         }


### PR DESCRIPTION
### What does this PR do
- Improve warnings during execution of `variants init`
- Specify which fields in `variants.yml` couldn't be populated automatically for iOS

### How can it be tested
- Adhere to the [latest changes](https://github.com/Backbase/variants/commit/2bad20dc1ab9ac6275daf6db6e1ba475931063bb#diff-88e254e2c28df11e815768543a21790e7d60b64b331abcf1d324ef6f768e4043) in variants.yml
- Run `variants init` on the base folder of an iOS project that doesn't contain `variants.yml`

### Task
resolves #115 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
