### PR TITLE
Ask if 'variants.yml' should be overridden when running 'variants init'

### DIFF
--- a/Sources/VariantsCore/Factory/ProjectFactory.swift
+++ b/Sources/VariantsCore/Factory/ProjectFactory.swift
@@ -14,13 +14,15 @@ struct ProjectFactory {
         case .ios:
             return iOSProject(
                 specHelper: iOSSpecHelper(
-                    templatePath: Path("/ios/variants-template.yml")
+                    templatePath: Path("/ios/variants-template.yml"),
+                    userInputHelper: UserInputHelper()
                 )
             )
         case .android:
             return AndroidProject(
                 specHelper: AndroidSpecHelper(
-                    templatePath: Path("/android/variants-template.yml")
+                    templatePath: Path("/android/variants-template.yml"),
+                    userInputHelper: UserInputHelper()
                 )
             )
         }

--- a/Sources/VariantsCore/Helpers/UserInputHelper.swift
+++ b/Sources/VariantsCore/Helpers/UserInputHelper.swift
@@ -1,0 +1,47 @@
+//
+//  Variants
+//
+//  Copyright (c) Backbase B.V. - https://www.backbase.com
+//  Created by Arthur Alves
+//
+
+import Foundation
+import PathKit
+
+public class UserInputHelper {
+    public init(
+        logger: Logger = Logger.shared
+    ) {
+        self.logger = logger
+    }
+    
+    /// Asks the user (through interactive shell) if the Variants spec should be overriden.
+    /// - Returns: Bool
+    public func doesUserGrantPermissionToOverrideSpec() -> Bool {
+        let shouldOverrideSpec = Bool(userInput(
+            with: "'variants.yml' spec already exists! Should we override it?",
+            suggestion: "[Y]es / [N]o") { input -> Bool in
+            return ["y", "yes", "n", "no"].contains(input.lowercased())
+        }) ?? false
+        
+        return shouldOverrideSpec
+    }
+    
+    private func userInput(with description: String, suggestion: String, validation: (String) -> Bool) -> String  {
+        logger.logInfo("*  ", item: description)
+        logger.logInfo(suggestion, item: "")
+        guard let input = readLine(), validation(input) else {
+            logger.logInfo(item: " ")
+            return userInput(with: description, suggestion: suggestion, validation: validation)
+        }
+        logger.logInfo(item: " ")
+        if ["y", "yes"].contains(input.lowercased()) {
+            return "true"
+        } else if ["n", "no"].contains(input.lowercased()) {
+            return "false"
+        }
+        return input
+    }
+    
+    private let logger: Logger
+}

--- a/Sources/VariantsCore/Loggers/Logger.swift
+++ b/Sources/VariantsCore/Loggers/Logger.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public class Logger: VerboseLogger, Codable {
-    static let shared = Logger(verbose: false)
+    public static let shared = Logger(verbose: false)
     
     init(verbose: Bool) {
         self.isVerbose = verbose

--- a/Tests/VariantsCoreTests/AndroidProjectTests.swift
+++ b/Tests/VariantsCoreTests/AndroidProjectTests.swift
@@ -12,7 +12,10 @@ import ArgumentParser
 
 class AndroidProjectTests: XCTestCase {
     func testProject_initialize() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let gradleFactoryMock = MockGradleScriptFactory()
         let fastlaneFactoryMock = MockFastlaneFactory()
 
@@ -30,7 +33,10 @@ class AndroidProjectTests: XCTestCase {
     }
     
     func testProject_setup() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let gradleFactoryMock = MockGradleScriptFactory()
         let fastlaneFactoryMock = MockFastlaneFactory()
 
@@ -81,7 +87,10 @@ class AndroidProjectTests: XCTestCase {
     }
     
     func testProject_switch() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let gradleFactoryMock = MockGradleScriptFactory()
         let fastlaneFactoryMock = MockFastlaneFactory()
 

--- a/Tests/VariantsCoreTests/Mocks/MockFastlaneFactory.swift
+++ b/Tests/VariantsCoreTests/Mocks/MockFastlaneFactory.swift
@@ -36,7 +36,7 @@ class MockFastlaneFactory: ParametersFactory {
 class SpecHelperMock: SpecHelper {
     var generateCache: [Path] = []
     
-    override func generate(from path: Path) throws {
+    override func generate(from path: Path, userInputEnabled: Bool = false) throws {
         generateCache.append(path)
     }
 }

--- a/Tests/VariantsCoreTests/SpecHelperTests.swift
+++ b/Tests/VariantsCoreTests/SpecHelperTests.swift
@@ -19,8 +19,14 @@ class SpecHelperTests: XCTestCase {
     
     func testGenerateSpec_incorrectPath() {
         if let basePath = basePath() {
-            let specHelper = iOSSpecHelper(templatePath: incorrectTemplatePath)
-            XCTAssertThrowsError(try specHelper.generate(from: basePath), "Attempt to use an invalid path") { error in
+            let specHelper = iOSSpecHelper(
+                templatePath: incorrectTemplatePath,
+                userInputHelper: UserInputHelper()
+            )
+            XCTAssertThrowsError(
+                try specHelper.generate(from: basePath, userInputEnabled: false),
+                "Attempt to use an invalid path"
+            ) { error in
                 XCTAssertEqual(error.localizedDescription, """
                     The file “unknown-variants-template.yml” couldn’t be opened because there is no such file.
                     """)
@@ -34,7 +40,10 @@ class SpecHelperTests: XCTestCase {
             if variantsPath.exists {
                 XCTAssertNoThrow(try variantsPath.delete())
             }
-            let specHelper = iOSSpecHelper(templatePath: correctTemplatePath)
+            let specHelper = iOSSpecHelper(
+                templatePath: correctTemplatePath,
+                userInputHelper: UserInputHelper()
+            )
             XCTAssertNoThrow(try specHelper.generate(from: basePath))
             
             XCTAssertTrue(variantsPath.exists)

--- a/Tests/VariantsCoreTests/iOSProjectTests.swift
+++ b/Tests/VariantsCoreTests/iOSProjectTests.swift
@@ -13,7 +13,10 @@ import ArgumentParser
 
 class iOSProjectTests: XCTestCase {
     func testProject_initialize() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let xcFactoryMock = MockXCcodeConfigFactory(logLevel: true)
         let parametersFactoryMock = MockFastlaneFactory()
         
@@ -31,7 +34,10 @@ class iOSProjectTests: XCTestCase {
     }
     
     func testProject_setup() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let xcFactoryMock = MockXCcodeConfigFactory(logLevel: true)
         let parametersFactoryMock = MockFastlaneFactory()
         
@@ -73,7 +79,10 @@ class iOSProjectTests: XCTestCase {
     }
     
     func testProject_switch() {
-        let specHelperMock = SpecHelperMock(templatePath: Path("variants-template.yml"))
+        let specHelperMock = SpecHelperMock(
+            templatePath: Path("variants-template.yml"),
+            userInputHelper: UserInputHelper()
+        )
         let xcFactoryMock = MockXCcodeConfigFactory(logLevel: true)
         let parametersFactoryMock = MockFastlaneFactory()
         
@@ -99,15 +108,12 @@ class iOSProjectTests: XCTestCase {
         
         XCTAssertNotNil(specPath())
         if let spec = specPath() {
-            
             // Variant 'variant' doesn't exist
             XCTAssertThrowsError(try project.switch(to: inexistentVariant, spec: spec.string, verbose: true),
                                  "Variant doesn't exist") { (error) in
                 XCTAssertNotNil(error as? ValidationError)
                 if let validationError = error as? ValidationError {
-                    XCTAssertEqual(validationError.description, """
-                        Variant '\(inexistentVariant)' not found.
-                        """)
+                    XCTAssertEqual(validationError.description, "Variant '\(inexistentVariant)' not found.")
                 }
             }
             
@@ -118,7 +124,7 @@ class iOSProjectTests: XCTestCase {
             XCTAssertEqual(parametersFactoryMock.createMatchFileCache.count, 1)
             XCTAssertEqual(xcFactoryMock.createConfigCache.count, 1)
             XCTAssertEqual(xcFactoryMock.createConfigCache.first?.variant.name, "BETA")
-
+            
             let stgVariant = "stg"
             XCTAssertNoThrow(try project.switch(to: stgVariant, spec: spec.string, verbose: true))
             XCTAssertEqual(parametersFactoryMock.createParametersCache.count, 2)

--- a/Variants.xcodeproj/project.pbxproj
+++ b/Variants.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		8E6ABB9D25C031AB006A62FE /* UtilsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6ABB9C25C031AB006A62FE /* UtilsDirectory.swift */; };
 		8E6ABBA425C03639006A62FE /* SecretsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6ABBA325C03639006A62FE /* SecretsFactory.swift */; };
 		8E6ABBB625C03F2C006A62FE /* SecretsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6ABBAF25C03F05006A62FE /* SecretsFactoryTests.swift */; };
+		8E866A1725D2CCEA00A7EC19 /* UserInputHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E866A1625D2CCEA00A7EC19 /* UserInputHelper.swift */; };
 		8E8A483525514BE00056F79F /* Stencil in Frameworks */ = {isa = PBXBuildFile; productRef = 8E8A483425514BE00056F79F /* Stencil */; };
 		8E8A483C25514D3A0056F79F /* FastlaneParametersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8A483B25514D3A0056F79F /* FastlaneParametersFactory.swift */; };
 		8E8A485A255165F60056F79F /* FastlaneParametersFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8A4849255165CB0056F79F /* FastlaneParametersFactoryTests.swift */; };
@@ -166,6 +167,7 @@
 		8E6ABB9C25C031AB006A62FE /* UtilsDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsDirectory.swift; sourceTree = "<group>"; };
 		8E6ABBA325C03639006A62FE /* SecretsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SecretsFactory.swift; path = Sources/VariantsCore/Factory/ios/SecretsFactory.swift; sourceTree = SOURCE_ROOT; };
 		8E6ABBAF25C03F05006A62FE /* SecretsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsFactoryTests.swift; sourceTree = "<group>"; };
+		8E866A1625D2CCEA00A7EC19 /* UserInputHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInputHelper.swift; sourceTree = "<group>"; };
 		8E8A483B25514D3A0056F79F /* FastlaneParametersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastlaneParametersFactory.swift; sourceTree = "<group>"; };
 		8E8A4849255165CB0056F79F /* FastlaneParametersFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastlaneParametersFactoryTests.swift; sourceTree = "<group>"; };
 		8E8A4865255172CF0056F79F /* Path+SafeJoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SafeJoin.swift"; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 				OBJ_41 /* Bash.swift */,
 				OBJ_42 /* Constants.swift */,
 				OBJ_43 /* PlatformDetector.swift */,
+				8E866A1625D2CCEA00A7EC19 /* UserInputHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -707,6 +710,7 @@
 				8E1B9ECF254AC29D00DD0204 /* YamlParser.swift in Sources */,
 				8E8A4866255172CF0056F79F /* Path+SafeJoin.swift in Sources */,
 				8E1B9DC8254AC27500DD0204 /* iOSProject.swift in Sources */,
+				8E866A1725D2CCEA00A7EC19 /* UserInputHelper.swift in Sources */,
 				8E1B9E67254AC29500DD0204 /* Constants.swift in Sources */,
 				8E1B9EFA254AC2A900DD0204 /* AndroidSigning.swift in Sources */,
 				8E6ABBA425C03639006A62FE /* SecretsFactory.swift in Sources */,


### PR DESCRIPTION
### What does this PR do
- Prompts an interactive shell, in case a `'variants.yml'` spec already exists while running `'variants init'`.
- Overrides if input is one of the following: `y`, `Y`, `Yes`, `yes`
- Stops execution if input is one of the following: `n`, `N`, `No`, `no`

### How can it be tested
- Adhere to the [latest changes](https://github.com/Backbase/variants/commit/2bad20dc1ab9ac6275daf6db6e1ba475931063bb#diff-88e254e2c28df11e815768543a21790e7d60b64b331abcf1d324ef6f768e4043) in variants.yml
- Run `variants init` on a project's base folder where `variants.yml` already exists.

### Task
resolves #127 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
