### PR TITLE
Improve timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ distclean:
 clean: distclean
 	@rm -rf $(BUILDDIR)
 
+.PHONY: prepare_for_test
+prepare_for_test:
+	@rm -rf variants.yml
+
 .PHONY: test
-test:
+test: prepare_for_test
 	@swift test
 	@xcodebuild test -scheme VariantsCore 
 
@@ -74,4 +78,5 @@ lint:
 
 .PHONY: validation
 validation: lint coverage
+	@rm -rf variants.yml
 	@echo "Ready to go."

--- a/Sources/VariantsCore/Commands/Initializer.swift
+++ b/Sources/VariantsCore/Commands/Initializer.swift
@@ -22,15 +22,19 @@ public struct Initializer: ParsableCommand {
     @Option(name: .shortAndLong, help: "'ios' or 'android'")
     var platform: String = ""
     
+    @Flag(name: [.customLong("timestamps", withSingleDash: false),
+                 .customShort("t")], help: "Show timestamps.")
+    var showTimestamps = false
+    
     @Flag(name: .shortAndLong, help: "Log tech details for nerds")
     var verbose = false
 
     public mutating func run() throws {
-        let logger = Logger(verbose: verbose)
+        let logger = Logger(verbose: verbose, showTimestamp: showTimestamps)
         logger.logSection("$ ", item: "variants init", color: .ios)
 
         let detectedPlatform = try PlatformDetector.detect(fromArgument: platform)
-        let project = ProjectFactory.from(platform: detectedPlatform)
+        let project = ProjectFactory.from(platform: detectedPlatform, logger: logger)
         try project.initialize(verbose: verbose)
     }
 }

--- a/Sources/VariantsCore/Commands/Setup.swift
+++ b/Sources/VariantsCore/Commands/Setup.swift
@@ -29,15 +29,19 @@ public struct Setup: ParsableCommand {
     @Flag()
     var skipFastlane: Bool = false
     
+    @Flag(name: [.customLong("timestamps", withSingleDash: false),
+                 .customShort("t")], help: "Show timestamps.")
+    var showTimestamps = false
+    
     @Flag(name: .shortAndLong, help: "Log tech details for nerds")
     var verbose = false
     
     public mutating func run() throws {
-        let logger = Logger(verbose: verbose)
+        let logger = Logger(verbose: verbose, showTimestamp: showTimestamps)
         logger.logSection("$ ", item: "variants setup", color: .ios)
         
         let detectedPlatform = try PlatformDetector.detect(fromArgument: platform)
-        let project = ProjectFactory.from(platform: detectedPlatform)
+        let project = ProjectFactory.from(platform: detectedPlatform, logger: logger)
         try project.setup(spec: spec, skipFastlane: skipFastlane, verbose: verbose)
     }
 }

--- a/Sources/VariantsCore/Commands/Switch.swift
+++ b/Sources/VariantsCore/Commands/Switch.swift
@@ -28,15 +28,19 @@ public struct Switch: ParsableCommand {
     @Option(name: .shortAndLong, help: "Use a different yaml configuration spec")
     var spec: String = "variants.yml"
     
+    @Flag(name: [.customLong("timestamps", withSingleDash: false),
+                 .customShort("t")], help: "Show timestamps.")
+    var showTimestamps = false
+    
     @Flag(name: .shortAndLong, help: "Log tech details for nerds")
     var verbose = false
     
     public mutating func run() throws {
-        let logger = Logger(verbose: verbose)
+        let logger = Logger(verbose: verbose, showTimestamp: showTimestamps)
         logger.logSection("$ ", item: "variants switch --variant \(variant)", color: .ios)
         
         let detectedPlatform = try PlatformDetector.detect(fromArgument: platform)
-        let project = ProjectFactory.from(platform: detectedPlatform)
+        let project = ProjectFactory.from(platform: detectedPlatform, logger: logger)
         try project.switch(to: variant, spec: spec, verbose: verbose)
     }
 }

--- a/Sources/VariantsCore/Factory/ProjectFactory.swift
+++ b/Sources/VariantsCore/Factory/ProjectFactory.swift
@@ -9,11 +9,12 @@ import Foundation
 import PathKit
 
 struct ProjectFactory {
-    static func from(platform: Platform) -> Project {
+    static func from(platform: Platform, logger: Logger) -> Project {
         switch platform {
         case .ios:
             return iOSProject(
                 specHelper: iOSSpecHelper(
+                    logger: logger,
                     templatePath: Path("/ios/variants-template.yml"),
                     userInputSource: interactiveShell,
                     userInput: { readLine() }
@@ -22,6 +23,7 @@ struct ProjectFactory {
         case .android:
             return AndroidProject(
                 specHelper: AndroidSpecHelper(
+                    logger: logger,
                     templatePath: Path("/android/variants-template.yml"),
                     userInputSource: interactiveShell,
                     userInput: { readLine() }

--- a/Sources/VariantsCore/Helpers/SpecHelper.swift
+++ b/Sources/VariantsCore/Helpers/SpecHelper.swift
@@ -48,10 +48,12 @@ enum iOSProjectKey: String, CaseIterable {
 
 class SpecHelper {
     init(
+        logger: Logger,
         templatePath: Path,
         userInputSource: UserInputSource,
         userInput: @escaping UserInput
     ) {
+        self.logger = logger
         self.templatePath = templatePath
         self.userInputSource = userInputSource
         self.userInput = userInput
@@ -81,7 +83,7 @@ class SpecHelper {
         let sourcePath = Path(components: [path.absolute().string, templatePath.string])
         try sourcePath.copy(variantsPath)
 
-        Logger.shared.logInfo("📝  ", item: "Variants' spec generated with success at path '\(variantsPath)'", color: .green)
+        logger.logInfo("📝  ", item: "Variants' spec generated with success at path '\(variantsPath)'", color: .green)
     }
     
     var shouldPopulateSpec: Bool = true
@@ -89,6 +91,7 @@ class SpecHelper {
     let userInput: UserInput
     let variantsPath = Path("./variants.yml")
     let templatePath: Path
+    let logger: Logger
 }
 
 // MARK: - iOS
@@ -116,7 +119,7 @@ class iOSSpecHelper: SpecHelper {
         }
 
         if projectSpecificInformation.isEmpty {
-            Logger.shared.logWarning("⚠️  ", item: """
+            logger.logWarning("⚠️  ", item: """
                 We were unable to populate './variants.yml' automatically.
                 Please open the file and remove the placeholder values.
                 i.e.: '{{ VALUE }}'
@@ -141,7 +144,7 @@ class iOSSpecHelper: SpecHelper {
             
             warningMessage.appendLine("\nPlease replace their placeholders manually.")
             
-            Logger.shared.logWarning("⚠️  ", item: warningMessage)
+            logger.logWarning("⚠️  ", item: warningMessage)
         }
 
         // Remove remaining '*-e' file after `sed` in-file replacemnt

--- a/Sources/VariantsCore/Loggers/Logger.swift
+++ b/Sources/VariantsCore/Loggers/Logger.swift
@@ -10,12 +10,13 @@ import Foundation
 public class Logger: VerboseLogger, Codable {
     public static let shared = Logger(verbose: false)
     
-    init(verbose: Bool) {
+    init(verbose: Bool, showTimestamp: Bool = false) {
         self.isVerbose = verbose
+        self.shouldShowTimestamp = showTimestamp
     }
     
-    private let isVerbose: Bool
     public var verbose: Bool { return isVerbose }
+    public var showTimestamp: Bool { return shouldShowTimestamp }
     
     func logFatal(_ prefix: Any = "❌ ", item: Any, color: ShellColor = .red) {
         logError(prefix, item: item, color: color)
@@ -51,4 +52,7 @@ public class Logger: VerboseLogger, Codable {
     private func divider(logLevel: LogLevel) {
         log(item: "--------------------------------------------------------------------------------------", logLevel: logLevel)
     }
+    
+    private let isVerbose: Bool
+    private let shouldShowTimestamp: Bool
 }

--- a/Sources/VariantsCore/Loggers/VerboseLogger.swift
+++ b/Sources/VariantsCore/Loggers/VerboseLogger.swift
@@ -34,6 +34,7 @@ public enum LogLevel: String {
 
 public protocol VerboseLogger {
     var verbose: Bool { get }
+    var showTimestamp: Bool { get }
     func log(_ prefix: Any, item: Any, indentationLevel: Int, color: ShellColor, logLevel: LogLevel)
 }
 
@@ -52,13 +53,21 @@ extension VerboseLogger {
         }
         let indentation = String(repeating: "   ", count: indentationLevel)
         var command = ""
-        let arguments =  [
-            "\(logLevel.rawValue)",
-            "[\(Date().logTimestamp())]: ▸ ",
+        var arguments: [String] = []
+        
+        if showTimestamp {
+            arguments.append(contentsOf: [
+                "\(logLevel.rawValue)",
+                "[\(Date().logTimestamp())]: ▸ "
+            ])
+        }
+        
+        arguments.append(contentsOf: [
             "\(indentation)",
             "\(color.bold())\(prefix)",
             "\(color.rawValue)\(item)\(ShellColor.neutral.rawValue)"
-        ]
+        ])
+        
         arguments.forEach { command.append($0) }
         var outputStream = StandardErrorOutputStream()
         Swift.print(command, to: &outputStream)

--- a/Tests/VariantsCoreTests/AndroidProjectTests.swift
+++ b/Tests/VariantsCoreTests/AndroidProjectTests.swift
@@ -12,6 +12,7 @@ import ArgumentParser
 
 class AndroidProjectTests: XCTestCase {
     let specHelperMock = SpecHelperMock(
+        logger: Logger.shared,
         templatePath: Path("variants-template.yml"),
         userInputSource: interactiveShell,
         userInput: { "yes" }

--- a/Tests/VariantsCoreTests/ProjectFactoryTests.swift
+++ b/Tests/VariantsCoreTests/ProjectFactoryTests.swift
@@ -12,11 +12,15 @@ class ProjectFactoryTests: XCTestCase {
 
     func test_from() throws {
         XCTAssertEqual(
-            ProjectFactory.from(platform: .ios).specHelper.templatePath.string,
+            ProjectFactory
+                .from(platform: .ios, logger: Logger.shared)
+                .specHelper.templatePath.string,
             "/ios/variants-template.yml")
         
         XCTAssertEqual(
-            ProjectFactory.from(platform: .android).specHelper.templatePath.string,
+            ProjectFactory
+                .from(platform: .android, logger: Logger.shared)
+                .specHelper.templatePath.string,
             "/android/variants-template.yml")
     }
 

--- a/Tests/VariantsCoreTests/SpecHelperTests.swift
+++ b/Tests/VariantsCoreTests/SpecHelperTests.swift
@@ -20,6 +20,7 @@ class SpecHelperTests: XCTestCase {
     func testGenerateSpec_incorrectPath() {
         if let basePath = basePath() {
             let specHelper = iOSSpecHelper(
+                logger: Logger.shared,
                 templatePath: incorrectTemplatePath,
                 userInputSource: interactiveShell,
                 userInput: { "yes" }
@@ -40,6 +41,7 @@ class SpecHelperTests: XCTestCase {
         if let basePath = basePath() {
             let variantsPath = Path("./variants.yml")
             let specHelper = iOSSpecHelper(
+                logger: Logger.shared,
                 templatePath: correctTemplatePath,
                 userInputSource: interactiveShell,
                 userInput: { "yes" }

--- a/Tests/VariantsCoreTests/iOSProjectTests.swift
+++ b/Tests/VariantsCoreTests/iOSProjectTests.swift
@@ -13,6 +13,7 @@ import ArgumentParser
 
 class iOSProjectTests: XCTestCase {
     let specHelperMock = SpecHelperMock(
+        logger: Logger.shared,
         templatePath: Path("variants-template.yml"),
         userInputSource: interactiveShell,
         userInput: { "yes" }

--- a/Tests/VariantsTests/InitCommandTests.swift
+++ b/Tests/VariantsTests/InitCommandTests.swift
@@ -1,0 +1,53 @@
+//
+//  Variants
+//
+//  Copyright (c) Backbase B.V. - https://www.backbase.com
+//  Created by Arthur Alves
+//
+
+import XCTest
+import class Foundation.Bundle
+
+// swiftlint:disable line_length
+
+final class InitCommandTests: XCTestCase {
+    func testUsage_help() throws {
+        let arguments = ["init", "--help"]
+        
+        let expectedOutput = "OVERVIEW: Generate spec file - variants.yml\n\nUSAGE: variants init [--platform <platform>] [--timestamps] [--verbose]\n\nOPTIONS:\n  -p, --platform <platform>\n                          \'ios\' or \'android\' \n  -t, --timestamps        Show timestamps. \n  -v, --verbose           Log tech details for nerds \n  --version               Show the version.\n  -h, --help              Show help information.\n\n"
+
+        let output = try CLIExecutor.shared.run(with: arguments)
+        XCTAssertEqual(output, expectedOutput)
+    }
+    
+    #warning("Test 'testUsage_noExtraArguments' will always fail when running from Xcode.")
+    func testUsage_noExtraArguments() throws {
+        let arguments = ["init"]
+        
+        let expectedOutput = "\u{1B}[1;0m\u{1B}[0;0m--------------------------------------------------------------------------------------\u{1B}[0;0m\n\u{1B}[1;49;36m$ \u{1B}[0;49;36mvariants init\u{1B}[0;0m\n\u{1B}[1;0m\u{1B}[0;0m--------------------------------------------------------------------------------------\u{1B}[0;0m\n\u{1B}[1;32m📝  \u{1B}[0;32mVariants\' spec generated with success at path \'./variants.yml\'\u{1B}[0;0m\n\u{1B}[1;33m⚠️  \u{1B}[0;33mWe were unable to populate the following fields in the \'./variants.yml\' spec:\n\n    * ios.targets.fooTarget\n    * ios.targets.fooTarget.name\n    * ios.targets.fooTarget.bundle_id\n    * ios.targets.fooTarget.test_target\n    * ios.targets.fooTarget.app_icon\n    * ios.targets.fooTarget.source.path\n    * ios.targets.fooTarget.source.info\n\nPlease replace their placeholders manually.\n\u{1B}[0;0m\n"
+
+        let output = try CLIExecutor.shared.run(with: arguments)
+        XCTAssertEqual(output, expectedOutput)
+    }
+    
+    func testInit_unknownArgument() throws {
+        let arguments = ["init", "unknown-argument"]
+        
+        let expectedOutput =
+            """
+            Error: Unexpected argument \'unknown-argument\'
+            Usage: variants init [--platform <platform>] [--timestamps] [--verbose]
+              See \'variants init --help\' for more information.
+
+            """
+        
+        let output = try CLIExecutor.shared.run(with: arguments)
+        XCTAssertEqual(output, expectedOutput)
+    }
+    
+    static var allTests = [
+        ("testUsage_help", testUsage_help),
+        ("testUsage_noExtraArguments", testUsage_noExtraArguments),
+        ("testInit_unknownArgument", testInit_unknownArgument)
+    ]
+}

--- a/Tests/VariantsTests/VariantsTests.swift
+++ b/Tests/VariantsTests/VariantsTests.swift
@@ -32,26 +32,17 @@ final class VariantsTests: XCTestCase {
 
             """
 
-        let output = try run(with: arguments)
+        let output = try CLIExecutor.shared.run(with: arguments)
         XCTAssertEqual(output, expectedOutput)
     }
-    
-    func testInit_unknownArgument() throws {
-        
-        let arguments = ["init",
-                         "unknown-argument"]
-        
-        let expectedOutput =
-            """
-            Error: Unexpected argument \'unknown-argument\'
-            Usage: variants init [--platform <platform>] [--verbose]
-              See \'variants init --help\' for more information.
 
-            """
-        
-        let output = try run(with: arguments)
-        XCTAssertEqual(output, expectedOutput)
-    }
+    static var allTests = [
+        ("testUsage_noCommands", testUsage_noCommands)
+    ]
+}
+
+class CLIExecutor {
+    static var shared = CLIExecutor()
     
     /// Execute Variants with given arguments
     func run(with arguments: [String]) throws -> String? {
@@ -89,9 +80,4 @@ final class VariantsTests: XCTestCase {
         return Bundle.main.bundleURL
       #endif
     }
-
-    static var allTests = [
-        ("testUsage_noCommands", testUsage_noCommands),
-        ("testInit_unknownArgument", testInit_unknownArgument)
-    ]
 }

--- a/Variants.xcodeproj/project.pbxproj
+++ b/Variants.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		8E6ABBA425C03639006A62FE /* SecretsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6ABBA325C03639006A62FE /* SecretsFactory.swift */; };
 		8E6ABBB625C03F2C006A62FE /* SecretsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6ABBAF25C03F05006A62FE /* SecretsFactoryTests.swift */; };
 		8E866A1725D2CCEA00A7EC19 /* UserInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E866A1625D2CCEA00A7EC19 /* UserInput.swift */; };
+		8E866B0725D68CA900A7EC19 /* InitCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E866B0625D68CA900A7EC19 /* InitCommandTests.swift */; };
 		8E8A483525514BE00056F79F /* Stencil in Frameworks */ = {isa = PBXBuildFile; productRef = 8E8A483425514BE00056F79F /* Stencil */; };
 		8E8A483C25514D3A0056F79F /* FastlaneParametersFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8A483B25514D3A0056F79F /* FastlaneParametersFactory.swift */; };
 		8E8A485A255165F60056F79F /* FastlaneParametersFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8A4849255165CB0056F79F /* FastlaneParametersFactoryTests.swift */; };
@@ -168,6 +169,7 @@
 		8E6ABBA325C03639006A62FE /* SecretsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SecretsFactory.swift; path = Sources/VariantsCore/Factory/ios/SecretsFactory.swift; sourceTree = SOURCE_ROOT; };
 		8E6ABBAF25C03F05006A62FE /* SecretsFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsFactoryTests.swift; sourceTree = "<group>"; };
 		8E866A1625D2CCEA00A7EC19 /* UserInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInput.swift; sourceTree = "<group>"; };
+		8E866B0625D68CA900A7EC19 /* InitCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitCommandTests.swift; sourceTree = "<group>"; };
 		8E8A483B25514D3A0056F79F /* FastlaneParametersFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastlaneParametersFactory.swift; sourceTree = "<group>"; };
 		8E8A4849255165CB0056F79F /* FastlaneParametersFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastlaneParametersFactoryTests.swift; sourceTree = "<group>"; };
 		8E8A4865255172CF0056F79F /* Path+SafeJoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+SafeJoin.swift"; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_65 /* VariantsTests.swift */,
+				8E866B0625D68CA900A7EC19 /* InitCommandTests.swift */,
 				OBJ_66 /* XCTestManifests.swift */,
 			);
 			name = VariantsTests;
@@ -775,6 +778,7 @@
 			files = (
 				OBJ_456 /* VariantsTests.swift in Sources */,
 				OBJ_457 /* XCTestManifests.swift in Sources */,
+				8E866B0725D68CA900A7EC19 /* InitCommandTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,6 +13,15 @@ Commands:
   version         Prints the current version of this app
 ```
 
+### List of commands
+
+* [1. Initialize](#initialize)
+    * [Variants Spec](#variants-spec)
+    * [Custom configuration](#custom-configuration)
+    * [Signing configuration](#signing-configuration)
+* [2. Setup](#setup-multiple-build-variants-with-full-fastlane-integration)
+* [3. Switch](#switch-variants)
+
 ### Initialize
 
 Before running setup to create your deployment variants and Fastlane setup you need a YAML configuration file.
@@ -21,13 +30,15 @@ Run `variants init` in the base folder of your project.
 ```sh
 OVERVIEW: Generate spec file - variants.yml
 
-USAGE: variants init [--platform <platform>] [--verbose]
+USAGE: variants init [--platform <platform>] [--timestamps] [--verbose]
 
 OPTIONS:
-  -p, --platform <platform>  'ios' or 'android'
-  -v, --verbose 
-  -h, --help                 Show help information.
-      --version              Show the version.
+  -p, --platform <platform>
+                          'ios' or 'android'
+  -t, --timestamps        Show timestamps.
+  -v, --verbose           Log tech details for nerds
+  --version               Show the version.
+  -h, --help              Show help information.
 ```
 
 Examples
@@ -46,7 +57,7 @@ It will generate a variants.yml file in the base folder of your project
 
 > NOTE: Edit the file variants.yml accordingly.
 
-#### Config settings
+#### Variants Spec
 Your `variants.yml` spec will contain all the necessary fields. The information within `xcodeproj` and `targets` sections are populated automatically if a `.xcodeproj` is found in your working directory - otherwise, you'll be asked to update the placeholders in this file. It comes with one variant named `default`, which will be used whenever a variant isn't specified. You can then include custom variants, for which the following settings are required:
 * `name`
 * `version_name`
@@ -97,22 +108,29 @@ Configuration through custom properties can bring a lot of value to your variant
 
 See our [Custom Property documentation](CUSTOM_PROPERTY.md) for a better understanding and examples.
 
-### Setup multiple build variants with full fastlane integration.
+#### Signing configuration
 
-#### Using default configuration file (variants.yml)
+Code signing for iOS apps can also be handled through `variants.yml` as long as Fastlane Match is used.
+For more information see [Working with Fastlane Match](ios/WORKING_WITH_FASTLANE_MATCH.md).
+
+### Setup multiple build variants with full fastlane integration
+
+#### Using default spec file (variants.yml)
 
 ```sh
 OVERVIEW: Setup deployment variants (alongside Fastlane)
 
-USAGE: variants setup [--platform <platform>] [--spec <spec>] [--skip-fastlane] [--verbose]
+USAGE: variants setup [--platform <platform>] [--spec <spec>] [--skip-fastlane] [--timestamps] [--verbose]
 
 OPTIONS:
-  -p, --platform <platform>  'ios' or 'android'
-  -s, --spec <spec>          Use a different yaml configuration spec (default: variants.yml)
-      --skip-fastlane
-  -v, --verbose
-  -h, --help                 Show help information.
-      --version              Show the version.
+  -p, --platform <platform>
+                          'ios' or 'android'
+  -s, --spec <spec>       Use a different yaml configuration spec (default: variants.yml)
+  --skip-fastlane
+  -t, --timestamps        Show timestamps.
+  -v, --verbose           Log tech details for nerds
+  --version               Show the version.
+  -h, --help              Show help information.
 ```
 
 Examples
@@ -136,7 +154,7 @@ Setup will also configure your Xcode project to use this new configuration and m
 <img src="../Assets/Examples/Project_Example_Step_3.png" title="Setup completed">
 </p>
 
-#### Using a configuration file other than the default one
+#### Using a spec file other than the default one
 
 You might not always have `variants.yml`  in the base folder of your project or have it with a completely different name, for this reason you can specify its path as an option
 
@@ -155,18 +173,17 @@ In order to switch between project variants you don't need to modify the Xcode p
 ```sh
 OVERVIEW: Switch variants
 
-USAGE: variants switch [--variant <variant>] [--platform <platform>] [--spec <spec>] [--verbose]
-
-ARGUMENTS:
-  <variant>
+USAGE: variants switch [--variant <variant>] [--platform <platform>] [--spec <spec>] [--timestamps] [--verbose]
 
 OPTIONS:
-      --variant <value>       Desired variant (default: default)
-  -p, --platform <platform>   'ios' or 'android'
-  -s, --spec <spec>           Use a different yaml configuration spec (default: variants.yml)
-  -v, --verbose
-      --version               Show the version.
-  -h, --help                  Show help information.
+  --variant <variant>     Desired variant (default: default)
+  -p, --platform <platform>
+                          'ios' or 'android'
+  -s, --spec <spec>       Use a different yaml configuration spec (default: variants.yml)
+  -t, --timestamps        Show timestamps.
+  -v, --verbose           Log tech details for nerds
+  --version               Show the version.
+  -h, --help              Show help information.
 ```
 
 Examples
@@ -177,8 +194,3 @@ $ variants switch --variant beta
 # Specify platform (in case there are projects for different platforms in the working directory, this will be mandatory)
 $ variants switch --variant beta --platform ios
 ```
-
-### Signing iOS apps
-
-Code signing for iOS apps can also be handled through `variants.yml` as long as Fastlane Match is used.
-For more information see [Working with Fastlane Match](ios/WORKING_WITH_FASTLANE_MATCH.md).


### PR DESCRIPTION
### What does this PR do
- Introduce argument `-t | --timestamps` and only show timestamps on console logs when it's present

### How can it be tested
- Run `variants init`
- Run `variants init --timestamps`

### Task
resolves #130 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
