### PR TITLE
Fix `variants setup` for Android

### DIFF
--- a/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
@@ -103,7 +103,7 @@ class AndroidProject: Project {
             do {
                 let projectSourceFolder = configuration.path
                 let path = try TemplateDirectory().path
-                try Bash("cp", arguments: "-R", "\(path.absolute())/android/_fastlane/", projectSourceFolder)
+                try Bash("cp", arguments: "-R", "\(path.absolute())/android/_fastlane/", ".")
                     .run()
 
                 let baseSetupCompletedMessage =
@@ -129,7 +129,7 @@ class AndroidProject: Project {
 
                     """
                 
-                if Path("\(projectSourceFolder)/fastlane/").isDirectory {
+                if StaticPath.Fastlane.baseFolder.isDirectory {
                     guard let defaultVariant = configuration.variants
                             .first(where: { $0.name.lowercased() == "default" }) else {
                         throw ValidationError("Variant 'default' not found.")
@@ -145,9 +145,9 @@ class AndroidProject: Project {
                         Your setup is complete, congratulations! 🎉
                         However, you still need to provide some parameters in order for fastlane to run correctly.
 
-                        ⚠️  Check the files in '\(projectSourceFolder)/fastlane/parameters/', change the parameters
+                        ⚠️  Check the files in 'fastlane/parameters/', change the parameters
                             accordingly, provide environment variables when applicable.
-                        ⚠️  Note that the values in the file '\(projectSourceFolder)/fastlane/parameters/variants_params.rb'
+                        ⚠️  Note that the values in the file 'fastlane/parameters/variants_params.rb'
                             where generated automatically for configuration properties with 'fastlane' destination.
 
                         """
@@ -165,6 +165,9 @@ class AndroidProject: Project {
                 }
 
             } catch let error as ValidationError {
+                Logger.shared.logFatal(item: error.description)
+                
+            } catch let error as RuntimeError {
                 Logger.shared.logFatal(item: error.description)
                 
             } catch {

--- a/Sources/VariantsCore/Custom Types/TemplateDirectory.swift
+++ b/Sources/VariantsCore/Custom Types/TemplateDirectory.swift
@@ -25,7 +25,7 @@ struct TemplateDirectory {
 
         guard let path = firstDirectory else {
             let dirs = directories.joined(separator: " or ")
-            throw RuntimeError("❌ Templates folder not found in \(dirs)")
+            throw RuntimeError("Templates folder not found in \(dirs)")
         }
 
         self.path = path

--- a/Sources/VariantsCore/Custom Types/UtilsDirectory.swift
+++ b/Sources/VariantsCore/Custom Types/UtilsDirectory.swift
@@ -25,7 +25,7 @@ struct UtilsDirectory {
 
         guard let path = firstDirectory else {
             let dirs = directories.joined(separator: " or ")
-            throw RuntimeError("❌ Utils folder not found in \(dirs)")
+            throw RuntimeError("Utils folder not found in \(dirs)")
         }
 
         self.path = path

--- a/Sources/VariantsCore/Factory/FastlaneParametersFactory.swift
+++ b/Sources/VariantsCore/Factory/FastlaneParametersFactory.swift
@@ -83,13 +83,13 @@ class FastlaneParametersFactory: ParametersFactory {
             // Or does exist and 'isWritable'
             guard !parametersFile.exists
                     || parametersFile.isWritable else {
-                throw TemplateDoesNotExist(templateNames: [parentFolder.string])
+                throw RuntimeError("'\(parametersFile.abbreviate())' can't be modified, you don't have write permission.")
             }
             
             // Write to file
             try parametersFile.write(data)
         } else {
-            throw TemplateDoesNotExist(templateNames: [parentFolder.string])
+            throw RuntimeError("'\(parentFolder.abbreviate())' doesn't exist or isn't a directory.")
         }
     }
     

--- a/Sources/VariantsCore/Loggers/Logger.swift
+++ b/Sources/VariantsCore/Loggers/Logger.swift
@@ -18,8 +18,8 @@ public class Logger: VerboseLogger, Codable {
     public var verbose: Bool { return isVerbose }
     public var showTimestamp: Bool { return shouldShowTimestamp }
     
-    func logFatal(_ prefix: Any = "❌ ", item: Any, color: ShellColor = .red) {
-        if prefix == "❌ " && (item as? String)?.contains("❌") {
+    func logFatal(_ prefix: String = "❌ ", item: String, color: ShellColor = .red) {
+        if prefix == "❌ " && item.contains("❌") {
             logError(item: item, color: color)
         } else {
             logError(prefix, item: item, color: color)

--- a/Sources/VariantsCore/Loggers/Logger.swift
+++ b/Sources/VariantsCore/Loggers/Logger.swift
@@ -19,7 +19,11 @@ public class Logger: VerboseLogger, Codable {
     public var showTimestamp: Bool { return shouldShowTimestamp }
     
     func logFatal(_ prefix: Any = "❌ ", item: Any, color: ShellColor = .red) {
-        logError(prefix, item: item, color: color)
+        if prefix == "❌ " && (item as? String)?.contains("❌") {
+            logError(item: item, color: color)
+        } else {
+            logError(prefix, item: item, color: color)
+        }
         exit(1)
     }
     

--- a/Sources/VariantsCore/Loggers/Logger.swift
+++ b/Sources/VariantsCore/Loggers/Logger.swift
@@ -18,12 +18,8 @@ public class Logger: VerboseLogger, Codable {
     public var verbose: Bool { return isVerbose }
     public var showTimestamp: Bool { return shouldShowTimestamp }
     
-    func logFatal(_ prefix: String = "❌ ", item: String, color: ShellColor = .red) {
-        if prefix == "❌ " && item.contains("❌") {
-            logError(item: item, color: color)
-        } else {
-            logError(prefix, item: item, color: color)
-        }
+    func logFatal(_ prefix: Any = "❌ ", item: Any, color: ShellColor = .red) {
+        logError(prefix, item: item, color: color)
         exit(1)
     }
     

--- a/Sources/VariantsCore/Schemas/Android/AndroidConfiguration.swift
+++ b/Sources/VariantsCore/Schemas/Android/AndroidConfiguration.swift
@@ -47,7 +47,7 @@ public struct AndroidConfiguration: Codable {
         self.appName = try container.decode(String.self, forKey: .appName)
         self.appIdentifier = try container.decode(String.self, forKey: .appIdentifier)
         self.variants = definiteVariants
-        self.signing = try container.decode(AndroidSigning.self, forKey: .signing)
+        self.signing = try? container.decode(AndroidSigning.self, forKey: .signing)
         self.custom = try? container.decode([CustomProperty].self, forKey: .custom)
     }
     

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,12 @@
 coverage:
   status:
     project:
+      threshold: 5%
       core:
         paths:
           - Sources/VariantsCore
       tests:
         paths:
           - Tests/VariantsCoreTests
+
+    patch: no


### PR DESCRIPTION
### What does this PR do
- Decodes `android.signing` as optional
- Writes `fastlane/` in the base folder regardless of the path in `android.path`
- Throws `RuntimeError` with more descriptive error message when writing to fastlane parameter files
- Removes redundant ❌ when instantiating RuntimeError

### How can it be tested
- Generate new spec with `variants init`
- Replace the following placeholders with correct value:
  - `android.path`
  - `android.app_name`
  - `android.app_identifier`
- Run `variants setup`

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
