### PR TITLE
fix: inability to find 'Templates' folder when installing Variants with homebrew on Apple Silicon

### DIFF
--- a/Sources/VariantsCore/Custom Types/TemplateDirectory.swift
+++ b/Sources/VariantsCore/Custom Types/TemplateDirectory.swift
@@ -19,11 +19,23 @@ struct TemplateDirectory {
             "./Templates"
         ]
     ) throws {
-        let firstDirectory = directories
-            .map(Path.init(stringLiteral:))
-            .first(where: \.exists)
-
-        guard let path = firstDirectory else {
+        
+        var templateDirectories = directories.map(Path.init(stringLiteral:))
+        
+        if let variantsInstallationPath = try? Bash(
+            "which",
+            arguments: "variants"
+        ).capture() {
+            templateDirectories.append(
+                Path(variantsInstallationPath.replacingOccurrences(
+                    of: "/bin/variants",
+                    with: "/lib/variants/templates"
+                ))
+            )
+        }
+        
+        let firstFoundDirectory = templateDirectories.first(where: \.exists)
+        guard let path = firstFoundDirectory else {
             let dirs = directories.joined(separator: " or ")
             throw RuntimeError("Templates folder not found in \(dirs)")
         }

--- a/Sources/VariantsCore/Custom Types/UtilsDirectory.swift
+++ b/Sources/VariantsCore/Custom Types/UtilsDirectory.swift
@@ -19,11 +19,22 @@ struct UtilsDirectory {
             "./utils"
         ]
     ) throws {
-        let firstDirectory = directories
-            .map(Path.init(stringLiteral:))
-            .first(where: \.exists)
-
-        guard let path = firstDirectory else {
+        var utilsDirectories = directories.map(Path.init(stringLiteral:))
+        
+        if let variantsInstallationPath = try? Bash(
+            "which",
+            arguments: "variants"
+        ).capture() {
+            utilsDirectories.append(
+                Path(variantsInstallationPath.replacingOccurrences(
+                    of: "/bin/variants",
+                    with: "/lib/variants/utils"
+                ))
+            )
+        }
+        
+        let firstFoundDirectory = utilsDirectories.first(where: \.exists)
+        guard let path = firstFoundDirectory else {
             let dirs = directories.joined(separator: " or ")
             throw RuntimeError("Utils folder not found in \(dirs)")
         }


### PR DESCRIPTION
### What does this PR do
- Dynamically finds the tools' installation path, therefore able to infer the root path of `lib/variants/templates`.

### How can it be tested
- [Install Variants via homebrew on Apple Silicon](https://github.com/Backbase/variants#homebrew-recommended).
- Run `variants init` on a new project.
- It should no longer fail as reported in issue #177

### Task
resolves #177 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
