### PR TITLE
feat: build fat binary for archs arm64 and x86_64

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest]
         swift: ["5.5"]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ utilsdir = utils
 
 REPODIR = $(shell pwd)
 BUILDDIR = $(REPODIR)/.build
+PRODUCTDIR = $(BUILDDIR)/apple/Products/Release
 CIBUILDDIR = $(REPODIR)/.ci-build
 SOURCES = $(wildcard $(srcdir)/**/*.swift)
 TEMPLATES = $(templatesdir)
@@ -33,13 +34,15 @@ all: variants
 variants: $(SOURCES)
 	@swift build \
 		-c release \
+		--arch arm64 \
+		--arch x86_64 \
 		--disable-sandbox \
 		--build-path "$(BUILDDIR)"
 
 .PHONY: install
 install: variants
 	@install -d $(bindir) $(libdir)
-	@install "$(BUILDDIR)/release/variants" $(bindir)
+	@install "$(PRODUCTDIR)/variants" $(bindir)
 	@mkdir -p $(libdir)/variants
 	@cp -R "$(TEMPLATES)" $(libdir)/variants/
 	@cp -R "$(UTILS)" $(libdir)/variants/
@@ -54,7 +57,7 @@ ci:
 
 .PHONY: pre-ci
 pre-ci: variants
-	@cp "$(BUILDDIR)/release/variants" "$(CIBUILDDIR)/release/variants"
+	@cp "$(PRODUCTDIR)/variants" "$(CIBUILDDIR)/release/variants"
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
### What does this PR do
- Builds a fat binary for archs x86-64 and arm64

### How can it be tested
- Make build should generate a binary that contains both archs. Can be tested with `lipo -info path/to/variants`

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
