### PR TITLE
feature: Add github issue template. Add git create issue config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,18 +1,34 @@
 ---
-name: Bug
-about: Issue a bug
-title: Bug: 
-labels: bug
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
 assignees: ''
 
 ---
 
-## Basic information
+### Environment ###
+**Variants:**
+ - Way of installation: [e.g. Homebrew, Make, SPM]
+ - Version [e.g. 1.1.13]
 
-Variants version:
-macOS version:
-Swift version:
+**Your machine:**
+ - OS: [e.g. MacOS, Windows]
+ - Processor [e.g. Intel, Apple Silicon]
 
-## Bug/Issue
+**Project's platform:**
+ - Platform: [e.g. iOS, Android]
 
-Describe the bug you've encountered here.
+### Describe the bug ###
+ A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+1. Go to '...'
+2. Execute command '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add error logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Slack Variants channel
+    url: https://backbase.slack.com/archives/s-variants/
+    about: Please ask your questions here.


### PR DESCRIPTION
### What does this PR do
Adds template for creating bugs in GitHub. Also new configuration prevents create issues not from given templates (currently bug and feature). Additionally, in create new issue menu, will be link on variants Slack channel.
<img width="800" alt="Screenshot 2022-12-08 at 15 02 47" src="https://user-images.githubusercontent.com/93975733/206482685-91584145-d8e3-4620-9b16-143fa54aea68.png">

<img width="800" alt="Screenshot 2022-12-08 at 15 02 47" src="https://user-images.githubusercontent.com/93975733/206482754-04ccf856-5852-4210-81f2-d5de4ec429e3.png">

### How can it be tested
Go to issues and try to create a new bug

### Task
resolves #185 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
