### PR TITLE
Fix Code Generation with GYB

### DIFF
--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -15,4 +15,3 @@ jobs:
             args: --failOnErrors --no-publish-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -1,25 +1,17 @@
-# We are disabling Danger temporarily until we get a fix to the error
-# 
-# ERROR: Failed to parse JSON: valueNotFound(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "danger", intValue: nil), CodingKeys(stringValue: "github", intValue: nil), CodingKeys(stringValue: "reviews", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "user", intValue: nil)], debugDescription: "Cannot get keyed decoding container -- found null value instead", underlyingError: nil))
-# ERROR: Dangerfile eval failed at Dangerfile.swift
-# 
-# In short, if a user that is deleted left a comment in a PR, the author becomes null
-# which breaks the JSON parsing
+name: "Danger Swift"
 
-# name: "Danger Swift"
+on:
+  pull_request:
+    types: [ opened, synchronize, edited ]
 
-# on:
-#   pull_request:
-#     types: [ opened, synchronize, edited ]
-
-# jobs:
-#   danger-scan:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#       - name: Danger
-#         uses: danger/swift@3.20.2
-#         with:
-#             args: --failOnErrors --no-publish-check
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  danger-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Danger
+        uses: danger/swift@3.20.2
+        with:
+            args: --failOnErrors --no-publish-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -7,11 +7,10 @@ on:
 jobs:
   danger-scan:
     runs-on: ubuntu-latest
-    name: "Run Danger"
     steps:
       - uses: actions/checkout@v3
       - name: Danger
-        uses: danger/swift@3.15.0
+        uses: danger/swift@3.20.2
         with:
             args: --failOnErrors --no-publish-check
         env:

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -5,12 +5,15 @@ on:
     types: [ opened, synchronize, edited ]
 
 jobs:
-  danger-scan:
+  build:
     runs-on: ubuntu-latest
+    name: "Run Danger"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Danger
-        uses: danger/swift@3.6.1
+        uses: danger/swift@3.15.0
+        with:
+            args: --failOnErrors --no-publish-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, synchronize, edited ]
 
 jobs:
-  build:
+  danger-scan:
     runs-on: ubuntu-latest
     name: "Run Danger"
     steps:

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -1,17 +1,25 @@
-name: "Danger Swift"
+# We are disabling Danger temporarily until we get a fix to the error
+# 
+# ERROR: Failed to parse JSON: valueNotFound(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "danger", intValue: nil), CodingKeys(stringValue: "github", intValue: nil), CodingKeys(stringValue: "reviews", intValue: nil), _JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "user", intValue: nil)], debugDescription: "Cannot get keyed decoding container -- found null value instead", underlyingError: nil))
+# ERROR: Dangerfile eval failed at Dangerfile.swift
+# 
+# In short, if a user that is deleted left a comment in a PR, the author becomes null
+# which breaks the JSON parsing
 
-on:
-  pull_request:
-    types: [ opened, synchronize, edited ]
+# name: "Danger Swift"
 
-jobs:
-  danger-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Danger
-        uses: danger/swift@3.20.2
-        with:
-            args: --failOnErrors --no-publish-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# on:
+#   pull_request:
+#     types: [ opened, synchronize, edited ]
+
+# jobs:
+#   danger-scan:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Danger
+#         uses: danger/swift@3.20.2
+#         with:
+#             args: --failOnErrors --no-publish-check
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -3,11 +3,17 @@ name: SwiftLint
 on:
   pull_request:
     types: [ opened, synchronize ]
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
 
 jobs:
   SwiftLint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Run SwiftLint
-        run: swiftlint lint --strict --reporter github-actions-logging
+      - uses: actions/checkout@v3
+      - name: GitHub Action for SwiftLint
+        uses: stanfordbdhg/action-swiftlint@v4
+        with:
+          args: --strict --reporter github-actions-logging

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,9 @@ let package = Package(
             name: "danger-swift",
             url: "https://github.com/danger/swift.git",
             from: "3.5.0"
-        )
+        ),
+        .package(
+            url: "https://github.com/SimplyDanny/SwiftLintPlugins")
     ],
     targets: [
         .target(
@@ -46,7 +48,8 @@ let package = Package(
                 "Yams",
                 "XcodeProj",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "Stencil"
+                "Stencil",
+                "SwiftLintPlugins"
             ]
         ),
         .target(
@@ -57,7 +60,9 @@ let package = Package(
         ),
         .testTarget(
             name: "VariantsTests",
-            dependencies: ["Variants"]
+            dependencies: [
+                "Variants"
+            ]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ This file is responsible for:
 
 ## Installation
 
+### Dependencies
+
+In order to generate the code from templates, Variants requires Python 2.7. We recommend configuring the python version using a version management tool such as Pyenv.
+
+For details on how to install and use it check the [Pyenv repo](https://github.com/pyenv/pyenv).
+
 ### On Github Actions CI
 
 See [Switching Variants on CI](docs/GITHUB_ACTION.md) for a better understanding and examples.

--- a/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/AndroidProject.swift
@@ -101,7 +101,7 @@ class AndroidProject: Project {
         try gradleFactory.createScript(with: configuration, variant: defaultVariant)
     }
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     private func setupFastlane(with configuration: AndroidConfiguration, skip: Bool) {
         if skip {
             Logger.shared.logInfo("Skipped Fastlane setup", item: "")
@@ -183,7 +183,6 @@ class AndroidProject: Project {
             }
         }
     }
-    // swiftlint:enable function_body_length
     
     private func storeFastlaneParams(for variant: AndroidVariant, configuration: AndroidConfiguration) throws {
         var customProperties: [CustomProperty] = (variant.custom ?? []) + (configuration.custom ?? [])

--- a/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
@@ -5,11 +5,11 @@
 //  Created by Balazs Toth
 //
 
+// swiftlint:disable type_name
+
 import Foundation
 import ArgumentParser
 import PathKit
-
-// swiftlint:disable type_name
 
 class iOSProject: Project {
     init(
@@ -140,7 +140,7 @@ class iOSProject: Project {
             }
     }
 
-    // swiftlint:disable function_body_length
+    // swiftlint:disable:next function_body_length
     private func setupFastlane(with configuration: iOSConfiguration, skip: Bool) {
         if skip {
             Logger.shared.logInfo("Skipped Fastlane setup", item: "")
@@ -225,7 +225,6 @@ class iOSProject: Project {
             }
         }
     }
-    // swiftlint:enable function_body_length
     
     private func storeFastlaneParams(_ properties: [CustomProperty]) throws {
         let fastlaneProperties = properties.filter { $0.destination == .fastlane }

--- a/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
@@ -82,7 +82,11 @@ class VariantsFileFactory {
                 ).capture(stream: .stderr)
                 if let stdErr = gybStdErr, !stdErr.isEmpty {
                     if stdErr.contains("env: python3: No such file or directory") {
-                        logger.logFatal(item: "We're unable to find a 'python3' executable. Install 'python3' or ensure it's your executable path and try running this Variants command again.")
+                        logger.logFatal(item:
+                        """
+                            We're unable to find a 'python3' executable.
+                            Install 'python3' or ensure it's your executable path and try running this Variants command again.
+                        """)
                     } else {
                         logger.logFatal(item: stdErr as Any)
                     }

--- a/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
@@ -52,64 +52,67 @@ class VariantsFileFactory {
     }
     
     private func write(_ data: Data, using folder: Path = Path("/tmp/")) throws {
-        if folder.isDirectory, folder.exists {
-            let variantsGybFile = try folder.safeJoin(path: Path(StaticPath.Xcode.variantsGybFileName))
-            
-            // Only proceed to write to file if such doesn't yet exist
-            // Or does exist and 'isWritable'
-            guard !variantsGybFile.exists
-                    || variantsGybFile.isWritable else {
-                throw TemplateDoesNotExist(templateNames: [folder.string])
-            }
-            
-            // Write to file
-            try variantsGybFile.write(data)
-            
-            if
-                try UtilsDirectory().path.exists,
-                let gybExecutablePath = try? UtilsDirectory().path.safeJoin(path: "gyb"),
-                let fileContent = try? variantsGybFile.read(),
-                fileContent == data {
-                
-                let gybStdErr = try Bash(gybExecutablePath.absolute().description,
-                         arguments:
-                            "--line-directive",
-                            "",
-                            "-o",
-                            "Variants.swift",
-                            variantsGybFile.absolute().description
-                ).capture(stream: .stderr)
-                let variantsFilePath = "\(variantsGybFile.parent().abbreviate().string)/Variants.swift"
-                handleGybErrors(message: gybStdErr, variantsFilePath: variantsFilePath)
-                
-                logger.logInfo("⚙️  ", item: "'\(variantsFilePath)' has been generated with success", color: .green)
-            }
-        } else {
+        guard folder.isDirectory, folder.exists else {
             throw TemplateDoesNotExist(templateNames: [folder.string])
         }
+
+        let variantsGybFile = try folder.safeJoin(path: Path(StaticPath.Xcode.variantsGybFileName))
+        // Only proceed to write to file if such doesn't yet exist
+        // Or does exist and 'isWritable'
+        guard !variantsGybFile.exists || variantsGybFile.isWritable else {
+            throw TemplateDoesNotExist(templateNames: [folder.string])
+        }
+
+        try variantsGybFile.write(data)
+        guard
+            try UtilsDirectory().path.exists,
+            let gybExecutablePath = try? UtilsDirectory().path.safeJoin(path: "gyb"),
+            let fileContent = try? variantsGybFile.read(),
+            fileContent == data
+        else { return }
+
+        let gybStdErr = try Bash(gybExecutablePath.absolute().description,
+                 arguments:
+                    "--line-directive",
+                    "",
+                    "-o",
+                    "Variants.swift",
+                    variantsGybFile.absolute().description
+        ).capture(stream: .stderr)
+        let variantsFilePath = "\(variantsGybFile.parent().abbreviate().string)/Variants.swift"
+        handleGybErrors(message: gybStdErr, variantsFilePath: variantsFilePath)
+        logger.logInfo("⚙️  ", item: "'\(variantsFilePath)' has been generated with success", color: .green)
     }
     
     private func handleGybErrors(message: String?, variantsFilePath: String) {
-        if let stdErr = message, !stdErr.isEmpty {
-            if stdErr.contains("env: python2.7: No such file or directory") {
-                logger.logFatal(item:
-                """
-                We're unable to find a 'python2.7' executable.
-                Install 'python2.7' or ensure it's in your executables path and try running this Variants command again.
-                Tip:
-                    * Install pyenv (brew install pyenv)
-                    * Install python2.7 (pyenv install python2.7)
-                    * Add "$(pyenv root)/shims" to your PATH
-                """)
-            } else if stdErr.contains("for chunk in chunks(encode(os.environ.get(") {
-                logger.logFatal(item:
-                """
-                We're unable to create 'Variants.Secrets' in '\(variantsFilePath)'.
-                Ensure that custom config values whose `env: true` are actually environment variables.
-                """)
-            } else {
-                logger.logFatal(item: stdErr as Any)
-            }
+        guard let message, !message.isEmpty else { return }
+
+        switch message {
+        case _ where message.contains("env: python2.7: No such file or directory"):
+            logger.logFatal(item:
+            """
+            We're unable to find a 'python2.7' executable.
+            Install 'python2.7' or ensure it's in your executables path and try running this Variants command again.
+            Tip:
+                * Install pyenv (brew install pyenv)
+                * Install python2.7 (pyenv install python2.7)
+                * Add "$(pyenv root)/shims" to your PATH
+            """)
+        case _ where message.contains("for chunk in chunks(encode(os.environ.get("):
+            logger.logFatal(item:
+            """
+            We're unable to create 'Variants.Secrets' in '\(variantsFilePath)'.
+            Ensure that custom config values whose `env: true` are actually environment variables.
+            """)
+        case _ where message.contains("pyenv: python2.7: command not found"):
+            logger.logFatal(item:
+            """
+            Looks like you have pyenv installed but the current configured version is not correct.
+            Please, select the latest build of python 2.7 as local version.
+            For example: `pyenv local 2.7`
+            """)
+        default:
+            logger.logFatal(item: message as Any)
         }
     }
     

--- a/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/VariantsFileFactory.swift
@@ -72,14 +72,21 @@ class VariantsFileFactory {
                 let fileContent = try? variantsGybFile.read(),
                 fileContent == data {
                 
-                try Bash(gybExecutablePath.absolute().description,
+                let gybStdErr = try Bash(gybExecutablePath.absolute().description,
                          arguments:
                             "--line-directive",
                             "",
                             "-o",
                             "Variants.swift",
                             variantsGybFile.absolute().description
-                ).run()
+                ).capture(stream: .stderr)
+                if let stdErr = gybStdErr, !stdErr.isEmpty {
+                    if stdErr.contains("env: python3: No such file or directory") {
+                        logger.logFatal(item: "We're unable to find a 'python3' executable. Install 'python3' or ensure it's your executable path and try running this Variants command again.")
+                    } else {
+                        logger.logFatal(item: stdErr as Any)
+                    }
+                }
                 
                 logger.logInfo("⚙️  ", item: """
                     '\(variantsGybFile.parent().abbreviate().string)/Variants.swift' has been generated with success

--- a/Sources/VariantsCore/Helpers/SpecHelper.swift
+++ b/Sources/VariantsCore/Helpers/SpecHelper.swift
@@ -5,10 +5,10 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable type_name
+
 import Foundation
 import PathKit
-
-// swiftlint:disable type_name
 
 enum iOSProjectKey: String, CaseIterable {
     case project = "PROJECT"

--- a/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
@@ -5,9 +5,9 @@
 //  Created by Arthur Alves
 //
 
-import Foundation
-
 // swiftlint:disable type_name
+
+import Foundation
 
 internal extension CodingUserInfoKey {
     static let bundleID = CodingUserInfoKey(rawValue: "bundle_id")!

--- a/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
@@ -5,9 +5,9 @@
 //  Created by Arthur Alves
 //
 
-import Foundation
-
 // swiftlint:disable type_name
+
+import Foundation
 
 struct iOSSigning: Codable {
     let teamName: String?

--- a/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
@@ -5,9 +5,9 @@
 //  Created by Arthur Alves
 //
 
-import Foundation
-
 // swiftlint:disable type_name
+
+import Foundation
 
 public typealias NamedTarget = (key: String, value: iOSTarget)
 

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -5,9 +5,9 @@
 //  Created by Arthur Alves
 //
 
-import Foundation
-
 // swiftlint:disable type_name
+
+import Foundation
 
 public struct iOSVariant: Variant {
     let name: String

--- a/Templates/ios/Variants.swift.template.gyb
+++ b/Templates/ios/Variants.swift.template.gyb
@@ -28,29 +28,28 @@ public struct Variants {
     {% if configurationValues %}
     // MARK: - ConfigurationValueKey
     /// Custom configuration values coming from variants.yml as enum cases
-    
-    public enum ConfigurationValueKey: String { {% for confValue in configurationValues %}
-        case {{ confValue.name }} {% endfor %}
+
+    public enum ConfigurationValueKey: String {
+    {% for confValue in configurationValues %}
+        case {{ confValue.name }}{% endfor %}
     }
-    
+
     static func configurationValue(for key: ConfigurationValueKey) -> Any? {
         return Self.configuration[key.rawValue]
-    }
-    {% endif %}
-
+    }{% endif %}
     {% if secrets %}
     // MARK: - Secrets
     /// Encrypted secrets coming from variants.yml as environment variables
-    
+
     public struct Secrets {
-    
+
         private static let salt: [UInt8] = [
         %{ salt = [ord(byte) for byte in os.urandom(64)] }%
         % for chunk in chunks(salt, 8):
             ${"".join(["0x%02x, " % byte for byte in chunk])}
         % end
         ]
-    
+
     {% for secret in secrets %}
         static var {{ secret.name }}: String {
             let encoded: [UInt8] = [
@@ -62,7 +61,7 @@ public struct Variants {
             return decode(encoded, cipher: salt)
         }
     {% endfor %}
-    
+
         private static func decode(_ encoded: [UInt8], cipher: [UInt8]) -> String {
             String(decoding: encoded.enumerated().map { (offset, element) in
                 element ^ cipher[offset % cipher.count]

--- a/Tests/VariantsCoreTests/Mocks/MockXCcodeConfigFactory.swift
+++ b/Tests/VariantsCoreTests/Mocks/MockXCcodeConfigFactory.swift
@@ -5,10 +5,11 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable colon
+
 import Foundation
 import PathKit
 @testable import VariantsCore
-// swiftlint:disable colon
 
 class MockXCcodeConfigFactory: XCFactory {
     var writeContentCache: [(content: String, file: Path, force: Bool)] = []

--- a/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
+++ b/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
@@ -26,8 +26,19 @@ class VariantsFileFactoryTests: XCTestCase {
             }
             return infoDictionary
         }()
+        
+        // MARK: - ConfigurationValueKey
+        /// Custom configuration values coming from variants.yml as enum cases
+        public enum ConfigurationValueKey: String {
+        
+            case PROPERTY_A
+            case PROPERTY_B
+        }
+        static func configurationValue(for key: ConfigurationValueKey) -> Any? {
+            return Self.configuration[key.rawValue]
+        }
+        
     }
-    
     """
     
     private let defaultVariant = try? iOSVariant(
@@ -37,8 +48,10 @@ class VariantsFileFactoryTests: XCTestCase {
         appIcon: nil,
         appName: nil,
         storeDestination: "testFlight",
-        custom: [CustomProperty(name: "PROPERTY_A", value: "VALUE_A", destination: .project),
-                 CustomProperty(name: "PROPERTY_B", value: "VALUE_B", env: true, destination: .project)],
+        custom: [
+            CustomProperty(name: "PROPERTY_A", value: "VALUE_A", destination: .project),
+            CustomProperty(name: "PROPERTY_B", value: "VALUE_B", destination: .project)
+        ],
         idSuffix: nil,
         bundleID: nil,
         variantSigning: nil,
@@ -60,6 +73,8 @@ class VariantsFileFactoryTests: XCTestCase {
 
         let variantsFilePath = Bundle(for: type(of: self)).path(forResource: "Resources/ios/Variants", ofType: "swift")
         XCTAssertNotNil(variantsFilePath)
+        guard let variantsFile = variantsFilePath else { return }
+        XCTAssertEqual(try String(contentsOfFile: variantsFile), variantsSwiftContent)
     }
     
     func testUtilsDirectory_pathExists() {

--- a/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
+++ b/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
@@ -60,8 +60,6 @@ class VariantsFileFactoryTests: XCTestCase {
 
         let variantsFilePath = Bundle(for: type(of: self)).path(forResource: "Resources/ios/Variants", ofType: "swift")
         XCTAssertNotNil(variantsFilePath)
-//        guard let variantsFile = variantsFilePath else { return }
-//        XCTAssertEqual(try String(contentsOfFile: variantsFile), variantsSwiftContent)
     }
     
     func testUtilsDirectory_pathExists() {

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -74,7 +74,8 @@ class YamlParserTests: XCTestCase {
             }
         }
     }
-    // swiftlint:disable function_body_length
+
+    // swiftlint:disable:next function_body_length
     func testExtractConfiguration_valid_iOS() {
         let parser = YamlParser()
         do {
@@ -167,7 +168,7 @@ class YamlParserTests: XCTestCase {
             XCTAssertTrue(((error as? DecodingError) == nil))
         }
     }
-    // swiftlint:enable function_body_length
+
     func testExtractConfiguration_valid_android() {
         let parser = YamlParser()
         do {

--- a/Tests/VariantsCoreTests/iOSProjectTests.swift
+++ b/Tests/VariantsCoreTests/iOSProjectTests.swift
@@ -5,11 +5,12 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable type_name
+
 import XCTest
 import PathKit
 import ArgumentParser
 @testable import VariantsCore
-// swiftlint:disable type_name
 
 class iOSProjectTests: XCTestCase {
     let specHelperMock = SpecHelperMock(

--- a/Tests/VariantsCoreTests/iOSSigningTests.swift
+++ b/Tests/VariantsCoreTests/iOSSigningTests.swift
@@ -5,10 +5,10 @@
 //  Created by Roman Huti
 //
 
+// swiftlint:disable type_name
+
 import XCTest
 @testable import VariantsCore
-
-// swiftlint:disable type_name
 
 final class iOSSigningTests: XCTestCase {
     

--- a/Tests/VariantsTests/InitCommandTests.swift
+++ b/Tests/VariantsTests/InitCommandTests.swift
@@ -5,10 +5,10 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable line_length
+
 import XCTest
 import class Foundation.Bundle
-
-// swiftlint:disable line_length
 
 final class InitCommandTests: XCTestCase {
     func testUsage_help() throws {
@@ -33,8 +33,9 @@ final class InitCommandTests: XCTestCase {
         let output = try CLIExecutor.shared.run(with: arguments)
         XCTAssertEqual(output, expectedOutput)
     }
-    
-    #warning("Test 'testUsage_noExtraArguments' will always fail when running from Xcode.")
+
+    /// Note:
+    /// Test testUsage_noExtraArguments' will always fail when running from Xcode.
     func testUsage_noExtraArguments() throws {
         let arguments = ["init"]
         

--- a/Variants.xcodeproj/project.pbxproj
+++ b/Variants.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -601,6 +601,7 @@
 			buildPhases = (
 				8E1B9CC9254AC1E700DD0204 /* Headers */,
 				8E1B9CCA254AC1E700DD0204 /* Sources */,
+				2D70A7582D0854F000DF5272 /* ShellScript */,
 				8E1B9CCB254AC1E700DD0204 /* Frameworks */,
 				8E1B9CCC254AC1E700DD0204 /* Resources */,
 			);
@@ -643,6 +644,7 @@
 			buildConfigurationList = OBJ_379 /* Build configuration list for PBXNativeTarget "Variants" */;
 			buildPhases = (
 				OBJ_382 /* Sources */,
+				2D70A7562D08548E00DF5272 /* ShellScript */,
 				OBJ_421 /* Frameworks */,
 				8E1BA14E254C43A900DD0204 /* Embed Frameworks */,
 			);
@@ -710,6 +712,7 @@
 				8E1BA105254C3FD000DD0204 /* XCRemoteSwiftPackageReference "xcodeproj" */,
 				8E1BA10E254C3FFF00DD0204 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 				8E8A483325514BE00056F79F /* XCRemoteSwiftPackageReference "Stencil" */,
+				2D70A7512D08525300DF5272 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			productRefGroup = OBJ_274 /* Products */;
 			projectDirPath = "";
@@ -749,6 +752,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2D70A7562D08548E00DF5272 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SWIFT_PACKAGE_DIR=\"${BUILD_DIR%Build/*}SourcePackages/artifacts\"\nSWIFTLINT_CMD=$(ls \"$SWIFT_PACKAGE_DIR\"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint | head -n 1)\n\nif test -f \"$SWIFTLINT_CMD\" 2>&1\nthen\n    \"$SWIFTLINT_CMD\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
+		};
+		2D70A7582D0854F000DF5272 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "SWIFT_PACKAGE_DIR=\"${BUILD_DIR%Build/*}SourcePackages/artifacts\"\nSWIFTLINT_CMD=$(ls \"$SWIFT_PACKAGE_DIR\"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint | head -n 1)\n\nif test -f \"$SWIFTLINT_CMD\" 2>&1\nthen\n    \"$SWIFTLINT_CMD\"\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8E1B9CCA254AC1E700DD0204 /* Sources */ = {
@@ -1481,6 +1523,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		2D70A7512D08525300DF5272 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.57.1;
+			};
+		};
 		8E1BA0F3254C3F3E00DD0204 /* XCRemoteSwiftPackageReference "PathKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kylef/PathKit.git";

--- a/samples/ios/VariantsTestApp/VariantsTestApp/ViewController.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/ViewController.swift
@@ -7,9 +7,4 @@
 
 import UIKit
 
-class ViewController: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
-    }
-}
+class ViewController: UIViewController { }

--- a/utils/gyb
+++ b/utils/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 import gyb
 gyb.main()

--- a/utils/gyb
+++ b/utils/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2.7
 import gyb
 gyb.main()


### PR DESCRIPTION
### What does this PR do
- When capturing the output of a Bash command, select either `stdout` or `stderr` to be captured.
- Require `python2.7` to run `gyb` and default to a `fatalError` if not available. This prints an appropriate message to the user.
- It defaults to a `fatalError` when generating `Variants.Secrets` if environment variable used by a custom config doesn't exist.

### How can it be tested
- Run `variants switch` or `variants setup` without `python2.7` installed or in your executables path.
- Run `variants switch` or `variants setup` with at least one custom config whose `env: true` but `value` points to a non-existing environment variable.

### Task
Resolves #204 
Resolves #240 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
