### PR TITLE
Fix xcconfig randomly sorted generation

### DIFF
--- a/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
@@ -229,3 +229,5 @@ class iOSProject: Project {
     private let configFactory: XCFactory
     private let parametersFactory: ParametersFactory
 }
+
+// swiftlint:enable type_name

--- a/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
@@ -5,6 +5,8 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import XcodeProj
 import PathKit
@@ -249,3 +251,4 @@ private extension XcodeProjFactory {
     }
     // swiftlint:enable function_parameter_count
 }
+// swiftlint:enable file_length

--- a/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
@@ -247,4 +247,5 @@ private extension XcodeProjFactory {
                              target: target, autoSave: true)
         }
     }
+    // swiftlint:enable function_parameter_count
 }

--- a/Sources/VariantsCore/Helpers/SpecHelper.swift
+++ b/Sources/VariantsCore/Helpers/SpecHelper.swift
@@ -155,3 +155,5 @@ class iOSSpecHelper: SpecHelper {
 // MARK: - Android
 
 class AndroidSpecHelper: SpecHelper {}
+
+// swiftlint:enable type_name

--- a/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
@@ -39,3 +39,5 @@ public struct iOSConfiguration: Codable {
             .map { try iOSVariant(from: $1, name: $0, globalSigning: globalSigning) }
     }
 }
+
+// swiftlint:enable type_name

--- a/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSSigning.swift
@@ -92,3 +92,5 @@ extension iOSSigning {
         return signing
     }
 }
+
+// swiftlint:enable type_name

--- a/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSTarget.swift
@@ -32,3 +32,5 @@ public struct iOSSource: Codable {
     let info: String
     let config: String
 }
+
+// swiftlint:enable type_name

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -59,7 +59,7 @@ public struct iOSVariant: Variant {
         }
     }
     
-    func getDefaultValues(for target: iOSTarget) -> [String: String] {
+    func getDefaultValues(for target: iOSTarget) -> [(key: String, value: String)] {
         var customDictionary: [String: String] = [
             "V_APP_NAME": target.name + configName,
             "V_BUNDLE_ID": makeBundleID(for: target),
@@ -76,7 +76,7 @@ public struct iOSVariant: Variant {
             .filter { $0.destination == .project && !$0.isEnvironmentVariable }
             .forEach { customDictionary[$0.name] = $0.value }
         
-        return customDictionary
+        return customDictionary.sorted(by: {$0.key < $1.key})
     }
     
     private static func parseDestination(name: String, destination: String?) throws -> Destination? {

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -195,3 +195,5 @@ extension iOSVariant {
             globalSigning: globalSigning)
     }
 }
+
+// swiftlint:enable type_name

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -109,7 +109,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
         XCTAssertNoThrow(try factory.write(Data(correctOutput.utf8), using: path))
         XCTAssertEqual(try path.read(), correctOutput)
     }
-    
+    // swiftlint:disable function_body_length
     func testFileWrite_appendingStore() {
         let expectedOutput =
             """
@@ -170,7 +170,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
             XCTFail("'Try' should not throw - "+error.localizedDescription)
         }
     }
-    
+    // swiftlint:enable function_body_length
     private func context(for parameters: [CustomProperty]) -> [String: Any] {
         let fastlaneParameters = parameters.literal()
         let fastlaneEnvVars = parameters.envVars()

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -109,7 +109,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
         XCTAssertNoThrow(try factory.write(Data(correctOutput.utf8), using: path))
         XCTAssertEqual(try path.read(), correctOutput)
     }
-    // swiftlint:disable function_body_length
+
     func testFileWrite_appendingStore() {
         let expectedOutput =
             """
@@ -170,7 +170,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
             XCTFail("'Try' should not throw - "+error.localizedDescription)
         }
     }
-    // swiftlint:enable function_body_length
+
     private func context(for parameters: [CustomProperty]) -> [String: Any] {
         let fastlaneParameters = parameters.literal()
         let fastlaneEnvVars = parameters.envVars()

--- a/Tests/VariantsCoreTests/Mocks/MockXCcodeConfigFactory.swift
+++ b/Tests/VariantsCoreTests/Mocks/MockXCcodeConfigFactory.swift
@@ -48,3 +48,5 @@ class MockXCcodeConfigFactory: XCFactory {
     var xcconfigFileName: String = "variants.xcconfig"
     var logger: Logger
 }
+
+// swiftlint:enable colon

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -103,12 +103,21 @@ class YamlParserTests: XCTestCase {
                     iOSTarget(name: "FrankBank", app_icon: "AppIcon", bundleId: "com.backbase.frank.ios",
                               testTarget: "FrankBankTests", source: source)
             )
-            XCTAssertEqual(firstVariantDefaultValues?["V_VERSION_NUMBER"], "1")
-            XCTAssertEqual(firstVariantDefaultValues?["V_APP_NAME"], "FrankBank")
-            XCTAssertEqual(firstVariantDefaultValues?["V_BUNDLE_ID"], "com.backbase.frank.ios")
-            XCTAssertEqual(firstVariantDefaultValues?["V_APP_ICON"], "AppIcon")
-            XCTAssertEqual(firstVariantDefaultValues?["V_VERSION_NAME"], "0.0.1")
-            XCTAssertEqual(firstVariantDefaultValues?["SAMPLE_CONFIG"], "Production Value")
+            XCTAssertEqual(firstVariantDefaultValues?.count, 7)
+            XCTAssertEqual(firstVariantDefaultValues?[0].key, "SAMPLE_CONFIG")
+            XCTAssertEqual(firstVariantDefaultValues?[0].value, "Production Value")
+            XCTAssertEqual(firstVariantDefaultValues?[1].key, "V_APP_ICON")
+            XCTAssertEqual(firstVariantDefaultValues?[1].value, "AppIcon")
+            XCTAssertEqual(firstVariantDefaultValues?[2].key, "V_APP_NAME")
+            XCTAssertEqual(firstVariantDefaultValues?[2].value, "FrankBank")
+            XCTAssertEqual(firstVariantDefaultValues?[3].key, "V_BUNDLE_ID")
+            XCTAssertEqual(firstVariantDefaultValues?[3].value, "com.backbase.frank.ios")
+            XCTAssertEqual(firstVariantDefaultValues?[4].key, "V_MATCH_PROFILE")
+            XCTAssertEqual(firstVariantDefaultValues?[4].value, "match AppStore com.backbase.frank.ios")
+            XCTAssertEqual(firstVariantDefaultValues?[5].key, "V_VERSION_NAME")
+            XCTAssertEqual(firstVariantDefaultValues?[5].value, "0.0.1")
+            XCTAssertEqual(firstVariantDefaultValues?[6].key, "V_VERSION_NUMBER")
+            XCTAssertEqual(firstVariantDefaultValues?[6].value, "1")
             
             // MARK: - iOS Global Properties
             

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -6,7 +6,6 @@
 //
 
 // swiftlint:disable file_length
-// swiftlint:disable type_body_length
 
 import XCTest
 @testable import VariantsCore

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -6,6 +6,7 @@
 //
 
 // swiftlint:disable file_length
+// swiftlint:disable type_body_length
 
 import XCTest
 @testable import VariantsCore

--- a/Tests/VariantsCoreTests/iOSProjectTests.swift
+++ b/Tests/VariantsCoreTests/iOSProjectTests.swift
@@ -221,3 +221,5 @@ class iOSProjectTests: XCTestCase {
         ("testProject_setup_missingiOSConfiguration", testProject_setup_missingiOSConfiguration)
     ]
 }
+
+// swiftlint:enable type_name

--- a/Tests/VariantsCoreTests/iOSSigningTests.swift
+++ b/Tests/VariantsCoreTests/iOSSigningTests.swift
@@ -106,3 +106,5 @@ final class iOSSigningTests: XCTestCase {
     }
 
 }
+
+// swiftlint:enable type_name

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -251,48 +251,57 @@ class iOSVariantTests: XCTestCase {
     }
     
     func testGetDefaultValuesForTargetWithoutSigning() {
-        let expectedValues = [
-            "V_APP_NAME": "Target Name Beta",
-            "V_BUNDLE_ID": "com.Company.ValidName.beta",
-            "V_VERSION_NAME": "1.0.0",
-            "V_VERSION_NUMBER": "0",
-            "V_APP_ICON": "AppIcon"]
+        let expectedValues: [(key: String, value: String)] = [
+            (key: "V_APP_ICON", value: "AppIcon"),
+            (key: "V_APP_NAME", value: "Target Name Beta"),
+            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
+            (key: "V_VERSION_NAME", value: "1.0.0"),
+            (key: "V_VERSION_NUMBER", value: "0")
+        ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
-
-        XCTAssertEqual(variant.getDefaultValues(for: target), expectedValues)
+        let defaultValues = variant.getDefaultValues(for: target)
+        XCTAssertEqual(defaultValues.count, expectedValues.count)
+        defaultValues.enumerated().forEach({
+            XCTAssertEqual($1.key, expectedValues[$0].key)
+        })
     }
     
     func testGetDefaultValuesForTargetWithSigning() {
         let expectedValues = [
-            "V_APP_NAME": "Target Name Beta",
-            "V_BUNDLE_ID": "com.Company.ValidName.beta",
-            "V_VERSION_NAME": "1.0.0",
-            "V_VERSION_NUMBER": "0",
-            "V_APP_ICON": "AppIcon",
-            "V_MATCH_PROFILE": "match AppStore com.Company.ValidName.beta"]
+            (key: "V_APP_ICON", value: "AppIcon"),
+            (key: "V_APP_NAME", value: "Target Name Beta"),
+            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
+            (key: "V_MATCH_PROFILE", value: "match AppStore com.Company.ValidName.beta"),
+            (key: "V_VERSION_NAME", value: "1.0.0"),
+            (key: "V_VERSION_NUMBER", value: "0")
+        ]
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
 
-        XCTAssertEqual(variant.getDefaultValues(for: target), expectedValues)
+        let defaultValues = variant.getDefaultValues(for: target)
+        XCTAssertEqual(defaultValues.count, expectedValues.count)
+        defaultValues.enumerated().forEach({
+            XCTAssertEqual($1.key, expectedValues[$0].key)
+        })
     }
     
     func testGetDefaultValuesWithTargetAndCustomProperties() {
         let expectedValues = [
-            "V_APP_NAME": "Target Name Beta",
-            "V_BUNDLE_ID": "com.Company.ValidName.beta",
-            "V_VERSION_NAME": "1.0.0",
-            "V_VERSION_NUMBER": "0",
-            "V_APP_ICON": "AppIcon",
-            "V_MATCH_PROFILE": "match AppStore com.Company.ValidName.beta",
-            "Custom name": "Custom value"
+            (key: "Custom name", value: "Custom value"),
+            (key: "V_APP_ICON", value: "AppIcon"),
+            (key: "V_APP_NAME", value: "Target Name Beta"),
+            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
+            (key: "V_MATCH_PROFILE", value: "match AppStore com.Company.ValidName.beta"),
+            (key: "V_VERSION_NAME", value: "1.0.0"),
+            (key: "V_VERSION_NUMBER", value: "0")
         ]
         let customProperties = [
             CustomProperty(name: "Custom name", value: "Custom value", env: false, destination: .project),
@@ -304,9 +313,13 @@ class iOSVariantTests: XCTestCase {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
 
-        XCTAssertEqual(variant.getDefaultValues(for: target), expectedValues)
-        XCTAssertTrue(variant.getDefaultValues(for: target)["Custom name 2"] == nil, "Should not contains this property as it's an environment variable")
-        XCTAssertTrue(variant.getDefaultValues(for: target)["Custom name 3"] == nil, "Should not contains this property as it's not a project destination property")
+        let defaultValues = variant.getDefaultValues(for: target)
+        XCTAssertEqual(defaultValues.count, expectedValues.count)
+        defaultValues.enumerated().forEach({
+            XCTAssertEqual($1.key, expectedValues[$0].key)
+        })
+        XCTAssertFalse(defaultValues.contains(where: {$0.key == "Custom name 2"}), "Should not contains this property as it's an environment variable")
+        XCTAssertFalse(defaultValues.contains(where: {$0.key == "Custom name 3"}), "Should not contains this property as it's not a project destination property")
     }
     
     // MARK: - iOSVariants.Destination tests

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -365,3 +365,7 @@ class iOSVariantTests: XCTestCase {
         ("testParsingiOSVariantDestintation", testParsingiOSVariantDestintation)
     ]
 }
+
+// swiftlint:enable type_body_length
+// swiftlint:enable line_length
+// swiftlint:enable type_name

--- a/Tests/VariantsTests/InitCommandTests.swift
+++ b/Tests/VariantsTests/InitCommandTests.swift
@@ -65,3 +65,5 @@ final class InitCommandTests: XCTestCase {
         ("testInit_unknownArgument", testInit_unknownArgument)
     ]
 }
+
+// swiftlint:enable line_length

--- a/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
@@ -19,7 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication,
-                     configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+                     configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration",

--- a/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
@@ -9,28 +9,28 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(_ application: UIApplication,
+                     configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        return UISceneConfiguration(name: "Default Configuration",
+                                    sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    func application(_ application: UIApplication,
+                     didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // If any sessions were discarded while the application was not running,
+        // this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }
-

--- a/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/AppDelegate.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Arthur Alves on 10/02/2023.
 //
-// swiftlint:disable all
 
 import UIKit
 

--- a/samples/ios/VariantsTestApp/VariantsTestApp/SceneDelegate.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/SceneDelegate.swift
@@ -11,12 +11,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        // This delegate does not imply the connecting scene or session are new
+        // (see `application:configurationForConnectingSceneSession` instead).
+        // guard let _ = (scene as? UIWindowScene) else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -43,10 +45,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // Use this method to save data, release shared resources,
+        // and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }
-

--- a/samples/ios/VariantsTestApp/VariantsTestApp/SceneDelegate.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/SceneDelegate.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Arthur Alves on 10/02/2023.
 //
-// swiftlint:disable all
 
 import UIKit
 

--- a/samples/ios/VariantsTestApp/VariantsTestApp/Variants/Variants.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/Variants/Variants.swift
@@ -4,7 +4,6 @@
 //  Copyright (c) Backbase B.V. - https://www.backbase.com
 //  Created by Arthur Alves
 //
-// swiftlint:disable all
 
 import Foundation
 public struct Variants {

--- a/samples/ios/VariantsTestApp/VariantsTestApp/ViewController.swift
+++ b/samples/ios/VariantsTestApp/VariantsTestApp/ViewController.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Arthur Alves on 10/02/2023.
 //
-// swiftlint:disable all
 
 import UIKit
 


### PR DESCRIPTION
### What does this PR do
- This PR sorts the generated xcconfig file, to make sure that it's not random every time we generate a new one, this will make things easier to see what exactly changed in the xcconfig file between variants.

### How can it be tested
To test this PR, you can switch the variant, and see if the xcconfig file is sorted alphabetically.

### Task
resolves #219

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
