### PR TITLE
Supporting variants and pods configs simultaneously

### DIFF
--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -94,7 +94,7 @@ class XCConfigFactory: XCFactory {
         _ = write("", toFile: xcodeConfigPath, force: true)
         logger.logInfo("Created file: ", item: "'\(xcconfigFileName)' at \(xcodeConfigPath.parent().abbreviate().description)")
         
-        populateConfig(with: target.value, configFile: xcodeConfigPath, variant: variant)
+        populateConfig(with: target, configFile: xcodeConfigPath, variant: variant)
 
         /*
          * If template files should be added to Xcode Project
@@ -165,10 +165,10 @@ class XCConfigFactory: XCFactory {
         }
     }
     
-    private func populateConfig(with target: iOSTarget, configFile: Path, variant: iOSVariant) {
+    private func populateConfig(with target: NamedTarget, configFile: Path, variant: iOSVariant) {
         logger.logInfo("Populating: ", item: "'\(configFile.lastComponent)'")
-        importPodsIfNeeded(configFile: configFile)
-        variant.getDefaultValues(for: target).forEach { (key, value) in
+        importPodsIfNeeded(target: target, configFile: configFile)
+        variant.getDefaultValues(for: target.value).forEach { (key, value) in
             let stringContent = "\(key) = \(value)"
             logger.logDebug("Item: ", item: stringContent, indentationLevel: 1, color: .purple)
             
@@ -179,12 +179,13 @@ class XCConfigFactory: XCFactory {
         }
     }
     
-    private func importPodsIfNeeded(configFile: Path) {
+    private func importPodsIfNeeded(target: NamedTarget, configFile: Path) {
         guard StaticPath.Pod.podFileFile.exists else { return }
         
-        // this regex finds a folder that starts with Pods and doesn't end with Tests, so we can take the
-        let podConfigFileRegex: String = "./Pods/Target Support Files/Pods.*[^Tests]/.*\\.release\\.xcconfig"
-        guard let podsConfigFile: String = try? Bash("find", arguments: ".", "-regex", podConfigFileRegex).capture() else {
+        // this regex finds a folder that starts with Pods and ends with the target key, so we can take the
+        let podConfigFileRegex: String = "./Pods/Target Support Files/Pods.*-\(target.key)/.*\\.release\\.xcconfig"
+        guard let podsConfigFile: String = try? Bash("find | head -n 1", arguments: ".", "-regex", podConfigFileRegex).capture(),
+              !podsConfigFile.isEmpty else {
             logger.logError("❌ ", item: "Failed to import Pods config in .xcconfig, Pod config file not found")
             return
         }

--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -182,7 +182,7 @@ class XCConfigFactory: XCFactory {
     private func importPodsIfNeeded(target: NamedTarget, configFile: Path) {
         guard StaticPath.Pod.podFileFile.exists else { return }
         
-        // this regex finds a folder that starts with Pods and ends with the target key, so we can take the
+        // this regex finds a folder that starts with Pods and ends with the target key, with a ".release.xcconfig" extension.
         let podConfigFileRegex: String = "./Pods/Target Support Files/Pods.*-\(target.key)/.*\\.release\\.xcconfig"
         guard let podsConfigFile: String = try? Bash("find | head -n 1", arguments: ".", "-regex", podConfigFileRegex).capture(),
               !podsConfigFile.isEmpty else {

--- a/Sources/VariantsCore/Helpers/Constants.swift
+++ b/Sources/VariantsCore/Helpers/Constants.swift
@@ -30,6 +30,10 @@ struct StaticPath {
         static let variantsFileName = "Variants.swift"
     }
     
+    struct Pod {
+        static let podFileFile = Path("Podfile")
+    }
+    
     struct Template {
         static let variantsScriptFileName = "variants-template.gradle"
         static let fastlaneParametersFileName = "variants_params_template.rb"


### PR DESCRIPTION
### What does this PR do
- This PR is to add the feature where configs of Cocoa Pods are imported in variants.xcconfig only if Pods file is present, and if the config in Target Support Files is also present.

### How can it be tested
We can run variants switch on a project with a Podfile and the config in `./Pods/Target Support Files/...` is present and check if the `#include ...` is added at the top of the variants.xcconfig file,
and then run variants switch on a project without a Podfile ( `#include ...` shouldn't be there )
and then run variants switch on a project with a Podfile but without the config in `./Pods/Target Support Files/...`, you should receive an error in the terminal

### Task
No task for this one

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
