### PR TITLE
Add PostSwitchScript to iOSConfiguration and to iOSVariant

### DIFF
--- a/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
+++ b/Sources/VariantsCore/Custom Types/Project/iOSProject.swift
@@ -48,6 +48,10 @@ class iOSProject: Project {
         } catch {
             throw RuntimeError("Unable to switch variants - Check your YAML spec")
         }
+        
+        if let postSwitchScript = desiredVariant.postSwitchScript {
+            try self.runPostSwitchScript(postSwitchScript)
+        }
     }
     
     override func list(spec: String) throws -> [Variant] {
@@ -104,6 +108,11 @@ class iOSProject: Project {
                 
                 try parametersFactory.createMatchFile(using: variant, target: namedTarget.value)
             }
+    }
+    
+    private func runPostSwitchScript(_ script: String) throws {
+        guard let outputString = try Bash("bash", arguments: "-c", script).capture() else { return }
+        Logger.shared.logInfo(item: outputString)
     }
 
     private func createVariants(with configuration: iOSConfiguration, spec: String) throws {

--- a/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSConfiguration.swift
@@ -18,6 +18,8 @@ public struct iOSConfiguration: Codable {
     let targets: [String: iOSTarget]
     let variants: [iOSVariant]
     let custom: [CustomProperty]?
+    
+    private let postSwitchScript: String?
     private let signing: iOSSigning?
         
     var pbxproj: String {
@@ -31,12 +33,14 @@ public struct iOSConfiguration: Codable {
         self.targets = try container.decode([String: iOSTarget].self, forKey: .targets)
         self.custom = try? container.decode([CustomProperty].self, forKey: .custom)
         
+        let globalPostSwitchScript = try container.decodeIfPresent(String.self, forKey: .postSwitchScript)
         let globalSigning = try container.decodeIfPresent(iOSSigning.self, forKey: .signing)
         let variantsDict = try container.decode([String: UnnamediOSVariant].self, forKey: .variants)
         
+        self.postSwitchScript = globalPostSwitchScript
         self.signing = globalSigning
         self.variants = try variantsDict
-            .map { try iOSVariant(from: $1, name: $0, globalSigning: globalSigning) }
+            .map { try iOSVariant(from: $1, name: $0, globalSigning: globalSigning, globalPostSwitchScript: globalPostSwitchScript) }
     }
 }
 

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -39,7 +39,7 @@ public struct iOSVariant: Variant {
     init(
         name: String, versionName: String, versionNumber: Int, appIcon: String?, storeDestination: String?,
         custom: [CustomProperty]?, idSuffix: String?, bundleID: String?, variantSigning: iOSSigning?, globalSigning: iOSSigning?,
-        variantPostSwitchScript: String?, globalPostSwitchScript: String?)
+        globalPostSwitchScript: String?, variantPostSwitchScript: String?)
     throws {
         self.name = name
         self.versionName = versionName
@@ -50,8 +50,8 @@ public struct iOSVariant: Variant {
         self.custom = custom
         self.bundleNamingOption = try Self.parseBundleConfiguration(name: name, idSuffix: idSuffix, bundleID: bundleID)
         self.postSwitchScript = Self.parsePostSwitchScript(name: name,
-                                                           variantScript: variantPostSwitchScript,
-                                                           globalScript: globalPostSwitchScript)
+                                                           globalScript: globalPostSwitchScript,
+                                                           variantScript: variantPostSwitchScript)
     }
     
     func makeBundleID(for target: iOSTarget) -> String {
@@ -115,13 +115,13 @@ public struct iOSVariant: Variant {
         }
     }
     
-    private static func parsePostSwitchScript(name: String, variantScript: String?, globalScript: String?) -> String? {
-        if let variantScript = variantScript, let globalScript = globalScript {
-            return "\(variantScript)\n\(globalScript)"
-        } else if let variantScript = variantScript {
-            return variantScript
+    private static func parsePostSwitchScript(name: String, globalScript: String?, variantScript: String?) -> String? {
+        if let globalScript = globalScript, let variantScript = variantScript {
+            return "\(globalScript) && \(variantScript)"
         } else if let globalScript = globalScript {
             return globalScript
+        } else if let variantScript = variantScript {
+            return variantScript
         } else {
             return nil
         }
@@ -214,8 +214,8 @@ extension iOSVariant {
             bundleID: unnamediOSVariant.bundleID,
             variantSigning: unnamediOSVariant.signing,
             globalSigning: globalSigning,
-            variantPostSwitchScript: unnamediOSVariant.postSwitchScript,
-            globalPostSwitchScript: globalPostSwitchScript)
+            globalPostSwitchScript: globalPostSwitchScript,
+            variantPostSwitchScript: unnamediOSVariant.postSwitchScript)
     }
 }
 

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 // swiftlint:disable type_name
+// swiftlint:disable line_length
 
 public struct iOSVariant: Variant {
     let name: String
@@ -225,3 +226,4 @@ extension iOSVariant {
 }
 
 // swiftlint:enable type_name
+// swiftlint:enable line_length

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 // swiftlint:disable type_name
-// swiftlint:disable line_length
 
 public struct iOSVariant: Variant {
     let name: String
@@ -40,7 +39,8 @@ public struct iOSVariant: Variant {
     
     init(
         name: String, versionName: String, versionNumber: Int, appIcon: String?, appName: String?, storeDestination: String?,
-        custom: [CustomProperty]?, idSuffix: String?, bundleID: String?, variantSigning: iOSSigning?, globalSigning: iOSSigning?, globalPostSwitchScript: String?, variantPostSwitchScript: String?)
+        custom: [CustomProperty]?, idSuffix: String?, bundleID: String?, variantSigning: iOSSigning?, globalSigning: iOSSigning?,
+        globalPostSwitchScript: String?, variantPostSwitchScript: String?)
     throws {
         self.name = name
         self.versionName = versionName
@@ -51,8 +51,7 @@ public struct iOSVariant: Variant {
         self.signing = try Self.parseSigning(name: name, variantSigning: variantSigning, globalSigning: globalSigning)
         self.custom = custom
         self.bundleNamingOption = try Self.parseBundleConfiguration(name: name, idSuffix: idSuffix, bundleID: bundleID)
-        self.postSwitchScript = Self.parsePostSwitchScript(name: name,
-                                                           globalScript: globalPostSwitchScript,
+        self.postSwitchScript = Self.parsePostSwitchScript(globalScript: globalPostSwitchScript,
                                                            variantScript: variantPostSwitchScript)
     }
     
@@ -117,7 +116,7 @@ public struct iOSVariant: Variant {
         }
     }
     
-    private static func parsePostSwitchScript(name: String, globalScript: String?, variantScript: String?) -> String? {
+    private static func parsePostSwitchScript(globalScript: String?, variantScript: String?) -> String? {
         if let globalScript = globalScript, let variantScript = variantScript {
             return "\(globalScript) && \(variantScript)"
         } else if let globalScript = globalScript {
@@ -226,4 +225,3 @@ extension iOSVariant {
 }
 
 // swiftlint:enable type_name
-// swiftlint:enable line_length

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -110,7 +110,6 @@ class FastlaneParametersFactoryTests: XCTestCase {
         XCTAssertEqual(try path.read(), correctOutput)
     }
 
-    // swiftlint:disable function_body_length
     func testFileWrite_appendingStore() {
         let expectedOutput =
             """
@@ -173,7 +172,6 @@ class FastlaneParametersFactoryTests: XCTestCase {
             XCTFail("'Try' should not throw - "+error.localizedDescription)
         }
     }
-    // swiftlint:enable function_body_length
 
     private func context(for parameters: [CustomProperty]) -> [String: Any] {
         let fastlaneParameters = parameters.literal()

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -9,6 +9,8 @@ import XCTest
 import PathKit
 @testable import VariantsCore
 
+// swiftlint:disable function_body_length
+
 private let parameters = [
     CustomProperty(name: "sample", value: "sample-value", destination: .project),
     CustomProperty(name: "sample-2", value: "sample-2-value", destination: .fastlane),
@@ -135,8 +137,8 @@ class FastlaneParametersFactoryTests: XCTestCase {
             bundleID: nil,
             variantSigning: nil,
             globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
-            variantPostSwitchScript: "echo hello",
-            globalPostSwitchScript: "echo test")
+            globalPostSwitchScript: "echo global",
+            variantPostSwitchScript: "echo variant")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -203,3 +205,5 @@ fileprivate extension Sequence where Iterator.Element == CustomProperty {
             .filter({ $0.destination == .fastlane && !$0.isEnvironmentVariable })
     }
 }
+
+// swiftlint:enable function_body_length

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -110,6 +110,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
         XCTAssertEqual(try path.read(), correctOutput)
     }
 
+    // swiftlint:disable function_body_length
     func testFileWrite_appendingStore() {
         let expectedOutput =
             """
@@ -133,7 +134,9 @@ class FastlaneParametersFactoryTests: XCTestCase {
             idSuffix: "sample",
             bundleID: nil,
             variantSigning: nil,
-            globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""))
+            globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -170,6 +173,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
             XCTFail("'Try' should not throw - "+error.localizedDescription)
         }
     }
+    // swiftlint:enable function_body_length
 
     private func context(for parameters: [CustomProperty]) -> [String: Any] {
         let fastlaneParameters = parameters.literal()

--- a/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
+++ b/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
@@ -41,7 +41,9 @@ class VariantsFileFactoryTests: XCTestCase {
         idSuffix: nil,
         bundleID: nil,
         variantSigning: nil,
-        globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""))
+        globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
+        variantPostSwitchScript: "echo hello",
+        globalPostSwitchScript: "echo test")
     
     func testRender_noSecrets() {
         guard let configFile = Bundle(for: type(of: self))

--- a/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
+++ b/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
@@ -43,8 +43,8 @@ class VariantsFileFactoryTests: XCTestCase {
         bundleID: nil,
         variantSigning: nil,
         globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
-        variantPostSwitchScript: "echo hello",
-        globalPostSwitchScript: "echo test")
+        globalPostSwitchScript: "echo global",
+        variantPostSwitchScript: "echo variant")
     
     func testRender_noSecrets() {
         guard let configFile = Bundle(for: type(of: self))

--- a/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
+++ b/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
@@ -39,7 +39,7 @@ class XcodeProjFactoryTests: XCTestCase {
         guard let variant = try? iOSVariant(name: target.name, versionName: "", versionNumber: 0, appIcon: nil, appName: nil,
                                             storeDestination: nil, custom: nil, idSuffix: "", bundleID: nil, variantSigning: nil,
                                             globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
-                                            variantPostSwitchScript: nil, globalPostSwitchScript: nil)
+                                            globalPostSwitchScript: nil, variantPostSwitchScript: nil)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }

--- a/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
+++ b/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
@@ -38,7 +38,8 @@ class XcodeProjFactoryTests: XCTestCase {
                                source: .init(path: "", info: "", config: ""))
         guard let variant = try? iOSVariant(name: target.name, versionName: "", versionNumber: 0, appIcon: nil,
                                             storeDestination: nil, custom: nil, idSuffix: "", bundleID: nil, variantSigning: nil,
-                                            globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""))
+                                            globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""),
+                                            variantPostSwitchScript: nil, globalPostSwitchScript: nil)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -108,7 +108,7 @@ class iOSVariantTests: XCTestCase {
         XCTAssertNoThrow(try makeiOSVariant())
         
         let variant = try? makeiOSVariant()
-        XCTAssertEqual(variant?.postSwitchScript, "echo hello")
+        XCTAssertEqual(variant?.postSwitchScript, "echo variant")
     }
     
     func testInitiOSVariantsWithGlobalPostSwitchScript() {

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -21,10 +21,10 @@ class iOSVariantTests: XCTestCase {
     func testiOSVariantInitWithUnnamediOSVariant() {
         let customProperties = [CustomProperty(name: "Name", value: "Value", destination: .project)]
         let unnamedVariant = UnnamediOSVariant(versionName: "1.0", versionNumber: 0, appIcon: "app_icon", idSuffix: "beta", bundleID: nil,
-                                               signing: validSigning, custom: customProperties, storeDestination: "testflight")
+                                               signing: validSigning, custom: customProperties, storeDestination: "testflight", postSwitchScript: "echo hello")
         
         func makeiOSVariant() throws -> iOSVariant {
-            try iOSVariant(from: unnamedVariant, name: "beta", globalSigning: nil)
+            try iOSVariant(from: unnamedVariant, name: "beta", globalSigning: nil, globalPostSwitchScript: nil)
         }
         
         XCTAssertNoThrow(try makeiOSVariant())
@@ -37,13 +37,15 @@ class iOSVariantTests: XCTestCase {
         XCTAssertEqual(variant.storeDestination, iOSVariant.Destination(rawValue: unnamedVariant.storeDestination!.lowercased())!)
         XCTAssertEqual(variant.custom, unnamedVariant.custom)
         XCTAssertEqual(variant.makeBundleID(for: target), "com.Company.ValidName.beta")
+        XCTAssertEqual(variant.postSwitchScript, "echo hello")
     }
     
     // MARK: - Default property assigning
     func testInitNilFallbackToDefaultProperties() {
         func makeiOSVariant() throws -> iOSVariant {
             try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
-                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
         }
         
         XCTAssertNoThrow(try makeiOSVariant())
@@ -56,7 +58,8 @@ class iOSVariantTests: XCTestCase {
     func testGetTitle() {
         let name = "Variant Name"
         guard let variant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -66,7 +69,8 @@ class iOSVariantTests: XCTestCase {
     func testGetConfigName() {
         // Default variant
         guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                                   idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                                   idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                                   globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -75,7 +79,8 @@ class iOSVariantTests: XCTestCase {
         // Any variant
         let name = "Variant Name"
         guard let anyVariant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                               idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                               idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                               globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -85,7 +90,8 @@ class iOSVariantTests: XCTestCase {
     func testGetDestinationProperty() {
         let targetDestination = iOSVariant.Destination.appCenter
         guard let variant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: targetDestination.rawValue,
-                                            custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                            custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -97,6 +103,59 @@ class iOSVariantTests: XCTestCase {
         XCTAssertEqual(result.destination, expectedResult.destination)
     }
         
+    // MARK: - Post Switch Script tests
+    func testInitiOSVariantsWithVariantPostSwitchScript() {
+        func makeiOSVariant() throws -> iOSVariant {
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: nil)
+        }
+        
+        XCTAssertNoThrow(try makeiOSVariant())
+        
+        let variant = try? makeiOSVariant()
+        XCTAssertEqual(variant?.postSwitchScript, "echo hello")
+    }
+    
+    func testInitiOSVariantsWithGlobalPostSwitchScript() {
+        func makeiOSVariant() throws -> iOSVariant {
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: nil,
+                           globalPostSwitchScript: "echo test")
+        }
+        
+        XCTAssertNoThrow(try makeiOSVariant())
+        
+        let variant = try? makeiOSVariant()
+        XCTAssertEqual(variant?.postSwitchScript, "echo test")
+    }
+    
+    func testInitiOSVariantsWithVariantAndGlobalPostSwitchScript() {
+        func makeiOSVariant() throws -> iOSVariant {
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
+        }
+        
+        XCTAssertNoThrow(try makeiOSVariant())
+        
+        let variant = try? makeiOSVariant()
+        XCTAssertEqual(variant?.postSwitchScript, "echo hello\necho test")
+    }
+    
+    func testInitiOSVariantsWithNoPostSwitchScript() {
+        func makeiOSVariant() throws -> iOSVariant {
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: nil,
+                           globalPostSwitchScript: nil)
+        }
+        
+        XCTAssertNoThrow(try makeiOSVariant())
+        
+        let variant = try? makeiOSVariant()
+        XCTAssertNil(variant?.postSwitchScript)
+    }
+    
     // MARK: - Bundle ID and ID Suffix tests
     
     func testInitiOSVariantWithIDSuffixOrBundleID() {
@@ -111,7 +170,9 @@ class iOSVariantTests: XCTestCase {
             idSuffix: "beta",
             bundleID: nil,
             variantSigning: nil,
-            globalSigning: validSigning))
+            globalSigning: validSigning,
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test"))
         
         // Only Bundle ID
         XCTAssertNoThrow(try iOSVariant(
@@ -124,7 +185,9 @@ class iOSVariantTests: XCTestCase {
             idSuffix: nil,
             bundleID: "com.company.customBundle",
             variantSigning: nil,
-            globalSigning: validSigning))
+            globalSigning: validSigning,
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test"))
     }
     
     func testInitWithIDSuffixAndBundleID() {
@@ -137,7 +200,8 @@ class iOSVariantTests: XCTestCase {
         
         func makeiOSVariant() throws -> iOSVariant {
             try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                           idSuffix: "beta", bundleID: "com.company.customBundle", variantSigning: nil, globalSigning: validSigning)
+                           idSuffix: "beta", bundleID: "com.company.customBundle", variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
         }
         
         XCTAssertThrowsError(try makeiOSVariant(), "ID Suffix and Bundle ID can't be configured at same time in the same variant") { error in
@@ -155,7 +219,8 @@ class iOSVariantTests: XCTestCase {
         
         func makeiOSVariant() throws -> iOSVariant {
             try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                           idSuffix: nil, bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                           idSuffix: nil, bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
         }
         
         XCTAssertThrowsError(try makeiOSVariant(), "ID Suffix and Bundle ID can't be configured at same time in the same variant") { error in
@@ -166,7 +231,8 @@ class iOSVariantTests: XCTestCase {
     func testMakeBundleIDForVariant() {
         // ID Suffix provided
         guard let idSuffixVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                                    idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                                    idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                                    globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -174,7 +240,8 @@ class iOSVariantTests: XCTestCase {
                 
         // Bundle ID provided
         guard let bundleIDVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                                    idSuffix: nil, bundleID: "com.Overwritten.BundleID", variantSigning: nil, globalSigning: validSigning)
+                                                    idSuffix: nil, bundleID: "com.Overwritten.BundleID", variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                                    globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -182,7 +249,8 @@ class iOSVariantTests: XCTestCase {
         
         // Default variant
         guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                                   idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                                   idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                                   globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -203,7 +271,9 @@ class iOSVariantTests: XCTestCase {
             idSuffix: "beta",
             bundleID: nil,
             variantSigning: validSigning,
-            globalSigning: validSigning))
+            globalSigning: validSigning,
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test"))
         
         // Only variant signing defined
         XCTAssertNoThrow(try iOSVariant(
@@ -216,7 +286,9 @@ class iOSVariantTests: XCTestCase {
             idSuffix: "beta",
             bundleID: nil,
             variantSigning: validSigning,
-            globalSigning: nil))
+            globalSigning: nil,
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test"))
         
         // Only global signing defined
         XCTAssertNoThrow(try iOSVariant(
@@ -229,7 +301,9 @@ class iOSVariantTests: XCTestCase {
             idSuffix: "beta",
             bundleID: nil,
             variantSigning: nil,
-            globalSigning: validSigning))
+            globalSigning: validSigning,
+            variantPostSwitchScript: "echo hello",
+            globalPostSwitchScript: "echo test"))
     }
     
     func testInitWithoutSigningConfiguration() {
@@ -242,7 +316,8 @@ class iOSVariantTests: XCTestCase {
         
         func makeiOSVariant() throws -> iOSVariant {
             try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: nil)
+                           idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: nil, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
         }
         
         XCTAssertThrowsError(try makeiOSVariant(), "At least one signing needs to be provided") { error in
@@ -260,7 +335,8 @@ class iOSVariantTests: XCTestCase {
         ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
+                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing, variantPostSwitchScript: "echo hello",
+                                            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -281,7 +357,8 @@ class iOSVariantTests: XCTestCase {
             (key: "V_VERSION_NUMBER", value: "0")
         ]
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
-                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -308,7 +385,8 @@ class iOSVariantTests: XCTestCase {
             CustomProperty(name: "Custom name 2", value: "Custom value 2", env: true, destination: .project),
             CustomProperty(name: "Custom name 3", value: "Custom value 3", env: false, destination: .fastlane)]
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore",
-                                            custom: customProperties, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                                            custom: customProperties, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                                            globalPostSwitchScript: "echo test")
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
         }
@@ -326,7 +404,8 @@ class iOSVariantTests: XCTestCase {
     func testParsingiOSVariantDestintation() {
         func makeVariant(destination: String?) throws -> iOSVariant {
             try iOSVariant(name: "Variant Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: destination,
-                           custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
+                           custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning, variantPostSwitchScript: "echo hello",
+                           globalPostSwitchScript: "echo test")
         }
         
         // Should not throw if valid destination is provided

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -196,6 +196,12 @@ Configuration through custom properties can bring a lot of value to your variant
 
 See our [Custom Property documentation](CUSTOM_PROPERTY.md) for a better understanding and examples.
 
+#### Post Switch Script (iOS)
+
+Post Switch Script allows you to specify a script or command to run after switching variants. It can be provided globally and for each variant individually.
+
+For more information check [Using Post Switch Script](ios/POST_SWITCH_SCRIPT.md).
+
 #### Signing configuration
 
 Code signing for iOS apps can also be handled through `variants.yml` as long as Fastlane Match is used.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -87,6 +87,8 @@ ios:
             - name: apiBaseUrl
               value: https://sample.com/
               destination: project
+        postSwitchScript: |-
+            echo default Variant Done Switching
       BETA:
         id_suffix: beta
         app_icon: AppIcon.beta
@@ -100,6 +102,8 @@ ios:
             - key:  OTHER_SWIFT_FLAGS
               value: $(inherited) -DBETA
               destination: project
+    postSwitchScript: |-
+            echo global Done Switching
 ```
 ```yaml
 android:

--- a/docs/ios/POST_SWITCH_SCRIPT.md
+++ b/docs/ios/POST_SWITCH_SCRIPT.md
@@ -11,10 +11,9 @@ If you specify both a variant-specific and a global postSwitchScript, the global
 
 ### How to use it
 
-Testing the "Post Switch Script" feature is straightforward. Follow these steps:
+The "Post Switch Script" feature is optional for both local and global. In case you want to not use it you can simply omit the configuration in the `variants.yml` file.
 
-1. **Add a Post Switch Script to a Variant**:
-   - In your `variants.yml` file, add a `postSwitchScript` for a specific variant. For example:
+#### **Adding a Post Switch Script to a Variant**:   - In your `variants.yml` file, add a `postSwitchScript` for a specific variant. For example:
 
    ```yaml
    variants:
@@ -22,20 +21,16 @@ Testing the "Post Switch Script" feature is straightforward. Follow these steps:
        postSwitchScript: ./scripts/post_switch_variant1.sh
     ```
 
-2. **Add a global Post Switch Script**:
+#### **Adding a global Post Switch Script**:
    - Add a global postSwitchScript to your variants.yml file. This script will run after switching to any variant. For example:
 
    ```yaml
        postSwitchScript: ./scripts/post_switch_variant1.sh
     ```
 
-3. **Remove Both Scripts (Optional)**:
-
-    -If you want to ensure that the post-switch script is optional, simply remove both the variant-specific and global postSwitchScript entries from your configuration file.
-
 ### Script vs. Command
 
-One note about the naming here: "postSwitchScript" implies that you are providing a script to be run. However, in practice, you can also provide direct commands or the path to an executable bash file.
+The name "postSwitchScript" implies that you are providing a script to be run. However, in practice, you can also provide direct commands or the path to an executable bash file.
 
 - **Direct Commands**: You can specify commands directly in the postSwitchScript field. For example for single-line script:
    ```yaml
@@ -47,24 +42,22 @@ One note about the naming here: "postSwitchScript" implies that you are providin
       ```yaml
     variants:
       - name: variant1
-        postSwitchScript: echo "Hello, Variant 1"
+        postSwitchScript: >-
+            echo "My first multi-command" && 
+            echo "My second mulit-command"
    ```
 
 - **Executable Bash File**: You can provide the path to an executable bash file. For example:
    ```yaml
     variants:
       - name: variant1
-        postSwitchScript: |-
-            echo "Hello, Variant 1, line 1"
-            echo "Hello, Variant 1, line 2"
+        postSwitchScript: my_post_switch_script.sh
    ```
 
 ### Additional Notes
 
-Here are some additional details for users who may not be familiar with bash scripting:
-
 - **Direct Execution of Files**: You can execute files by writing their path directly in the postSwitchScript field.
 - **Multiple Commands**: If you want to execute multiple commands in the script, separate them using && (for sequential execution) or || (for conditional execution) at the end of each line.
-- **Multi-Line Commands**: Starting with |- is mandatory if you have multi-line commands or want to start a command on a new line for readability.
+- **Multi-Line Commands**: According to YAML specification, starting with |- is useful if you have multi-line commands or want to start a command on a new line for readability. Additionally, you should use >- instead of |- to strip the last \n.
 
 That's it! You are now ready to make the most of the "Post Switch Script" feature for your configuration needs.

--- a/docs/ios/POST_SWITCH_SCRIPT.md
+++ b/docs/ios/POST_SWITCH_SCRIPT.md
@@ -1,0 +1,70 @@
+## Using Post Switch Script 
+
+### What is a Post Switch Script?
+
+Post Switch Script allows you to specify a script or command to run after switching variants. Here's what it does:
+
+- **Variant-specific Post Switch Script**: You can define a script or command to run after switching to a particular variant.
+- **Global Post Switch Script**: You can also define a script or command to run after switching to any variant globally.
+
+If you specify both a variant-specific and a global postSwitchScript, the global one will run first, followed by the variant-specific one.
+
+### How to use it
+
+Testing the "Post Switch Script" feature is straightforward. Follow these steps:
+
+1. **Add a Post Switch Script to a Variant**:
+   - In your `variants.yml` file, add a `postSwitchScript` for a specific variant. For example:
+
+   ```yaml
+   variants:
+     - name: variant1
+       postSwitchScript: ./scripts/post_switch_variant1.sh
+    ```
+
+2. **Add a global Post Switch Script**:
+   - Add a global postSwitchScript to your variants.yml file. This script will run after switching to any variant. For example:
+
+   ```yaml
+       postSwitchScript: ./scripts/post_switch_variant1.sh
+    ```
+
+3. **Remove Both Scripts (Optional)**:
+
+    -If you want to ensure that the post-switch script is optional, simply remove both the variant-specific and global postSwitchScript entries from your configuration file.
+
+### Script vs. Command
+
+One note about the naming here: "postSwitchScript" implies that you are providing a script to be run. However, in practice, you can also provide direct commands or the path to an executable bash file.
+
+- **Direct Commands**: You can specify commands directly in the postSwitchScript field. For example for single-line script:
+   ```yaml
+    variants:
+      - name: variant1
+        postSwitchScript: echo "Hello, Variant 1"
+   ```
+   For example for multi-line script:
+      ```yaml
+    variants:
+      - name: variant1
+        postSwitchScript: echo "Hello, Variant 1"
+   ```
+
+- **Executable Bash File**: You can provide the path to an executable bash file. For example:
+   ```yaml
+    variants:
+      - name: variant1
+        postSwitchScript: |-
+            echo "Hello, Variant 1, line 1"
+            echo "Hello, Variant 1, line 2"
+   ```
+
+### Additional Notes
+
+Here are some additional details for users who may not be familiar with bash scripting:
+
+- **Direct Execution of Files**: You can execute files by writing their path directly in the postSwitchScript field.
+- **Multiple Commands**: If you want to execute multiple commands in the script, separate them using && (for sequential execution) or || (for conditional execution) at the end of each line.
+- **Multi-Line Commands**: Starting with |- is mandatory if you have multi-line commands or want to start a command on a new line for readability.
+
+That's it! You are now ready to make the most of the "Post Switch Script" feature for your configuration needs.

--- a/docs/ios/POST_SWITCH_SCRIPT.md
+++ b/docs/ios/POST_SWITCH_SCRIPT.md
@@ -7,57 +7,64 @@ Post Switch Script allows you to specify a script or command to run after switch
 - **Variant-specific Post Switch Script**: You can define a script or command to run after switching to a particular variant.
 - **Global Post Switch Script**: You can also define a script or command to run after switching to any variant globally.
 
-If you specify both a variant-specific and a global postSwitchScript, the global one will run first, followed by the variant-specific one.
+If you specify both a variant-specific and a global postSwitchScripts, the global one will run first, followed by the variant-specific one.
 
 ### How to use it
 
-The "Post Switch Script" feature is optional for both local and global. In case you want to not use it you can simply omit the configuration in the `variants.yml` file.
+The "Post Switch Script" feature is optional for both local and global. In case you don't want to use it you can simply omit the configuration in the `variants.yml` file.
 
-#### **Adding a Post Switch Script to a Variant**:   - In your `variants.yml` file, add a `postSwitchScript` for a specific variant. For example:
+#### Adding a Post Switch Script to a variant
+- In your `variants.yml` file, add a `postSwitchScript` for a specific variant. 
 
-   ```yaml
-   variants:
-     - name: variant1
-       postSwitchScript: ./scripts/post_switch_variant1.sh
-    ```
+```yaml
+variants:
+    variant_name:
+        postSwitchScript: ./scripts/post_switch_variant1.sh
+```
 
-#### **Adding a global Post Switch Script**:
-   - Add a global postSwitchScript to your variants.yml file. This script will run after switching to any variant. For example:
+#### Adding a global Post Switch Script
+- Add a global `postSwitchScript` to your `variants.yml` file. This script will run after switching to any variant.
 
-   ```yaml
-       postSwitchScript: ./scripts/post_switch_variant1.sh
-    ```
+```yaml
+postSwitchScript: ./scripts/post_switch_variant1.sh
+```
 
 ### Script vs. Command
 
 The name "postSwitchScript" implies that you are providing a script to be run. However, in practice, you can also provide direct commands or the path to an executable bash file.
 
-- **Direct Commands**: You can specify commands directly in the postSwitchScript field. For example for single-line script:
-   ```yaml
-    variants:
-      - name: variant1
+- **Direct Commands**: You can specify commands directly in the postSwitchScript field. 
+
+Single-line script:
+
+```yaml
+variants:
+    variant_name:
         postSwitchScript: echo "Hello, Variant 1"
-   ```
-   For example for multi-line script:
-      ```yaml
-    variants:
-      - name: variant1
+```
+
+Multi-line script:
+
+```yaml
+variants:
+    variant_name:
         postSwitchScript: >-
             echo "My first multi-command" && 
             echo "My second mulit-command"
-   ```
+```
 
-- **Executable Bash File**: You can provide the path to an executable bash file. For example:
-   ```yaml
-    variants:
-      - name: variant1
+- **Executable Bash File**: You can provide the path to an executable bash file. 
+
+```yaml
+variants:
+    variant_name:
         postSwitchScript: my_post_switch_script.sh
-   ```
+```
 
 ### Additional Notes
 
-- **Direct Execution of Files**: You can execute files by writing their path directly in the postSwitchScript field.
-- **Multiple Commands**: If you want to execute multiple commands in the script, separate them using && (for sequential execution) or || (for conditional execution) at the end of each line.
-- **Multi-Line Commands**: According to YAML specification, starting with |- is useful if you have multi-line commands or want to start a command on a new line for readability. Additionally, you should use >- instead of |- to strip the last \n.
+- **Direct Execution of Files**: You can execute files by writing their path directly in the `postSwitchScript` field.
+- **Multiple Commands**: If you want to execute multiple commands in the script, separate them using `&&` (for sequential execution) or `||` (for conditional execution) at the end of each line.
+- **Multi-Line Commands**: According to YAML specification, starting with `|-` is useful if you have multi-line commands or want to start a command on a new line for readability. Additionally, you might use `>-` instead of `|-` to strip the last `\n`.
 
 That's it! You are now ready to make the most of the "Post Switch Script" feature for your configuration needs.


### PR DESCRIPTION
### What does this PR do
- in this PR, post switch script is added, so whenever a user wants to run a specific script after switching variants, they can either do that for a specific variant, or for global switching, or for both
- if the user specifies both variant specific and global postSwitchScript, we will run the variants specific one first and then the global one

### How can it be tested
add a postSwitchScript to your variants.yml and it will be executed
- Add one postSwitchScript in a variant
- Add another one on the global layer of the yaml file
- Remove both to make sure that it's optional

### Task
resolves #X (where `#X` is the number of an issue)

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
