### PR TITLE
[216] Add ability to override app name per variant

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,10 +58,6 @@ let package = Package(
         .testTarget(
             name: "VariantsTests",
             dependencies: ["Variants"]
-        ),
-        .testTarget(
-            name: "VariantsCoreTests",
-            dependencies: ["Variants"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,10 @@ let package = Package(
         .testTarget(
             name: "VariantsTests",
             dependencies: ["Variants"]
+        ),
+        .testTarget(
+            name: "VariantsCoreTests",
+            dependencies: ["Variants"]
         )
     ]
 )

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -14,6 +14,7 @@ public struct iOSVariant: Variant {
     let versionName: String
     let versionNumber: Int
     let appIcon: String?
+    let appName: String?
     let storeDestination: Destination
     let signing: iOSSigning?
     let custom: [CustomProperty]?
@@ -35,13 +36,14 @@ public struct iOSVariant: Variant {
     }
     
     init(
-        name: String, versionName: String, versionNumber: Int, appIcon: String?, storeDestination: String?,
+        name: String, versionName: String, versionNumber: Int, appIcon: String?, appName: String?, storeDestination: String?,
         custom: [CustomProperty]?, idSuffix: String?, bundleID: String?, variantSigning: iOSSigning?, globalSigning: iOSSigning?)
     throws {
         self.name = name
         self.versionName = versionName
         self.versionNumber = versionNumber
         self.appIcon = appIcon
+        self.appName = appName
         self.storeDestination = try Self.parseDestination(name: name, destination: storeDestination) ?? .appStore
         self.signing = try Self.parseSigning(name: name, variantSigning: variantSigning, globalSigning: globalSigning)
         self.custom = custom
@@ -61,7 +63,7 @@ public struct iOSVariant: Variant {
     
     func getDefaultValues(for target: iOSTarget) -> [(key: String, value: String)] {
         var customDictionary: [String: String] = [
-            "V_APP_NAME": target.name + configName,
+            "V_APP_NAME": appName ?? target.name + configName,
             "V_BUNDLE_ID": makeBundleID(for: target),
             "V_VERSION_NAME": versionName,
             "V_VERSION_NUMBER": String(versionNumber),
@@ -148,6 +150,7 @@ struct UnnamediOSVariant: Codable {
     let versionName: String
     let versionNumber: Int
     let appIcon: String?
+    let appName: String?
     let idSuffix: String?
     let bundleID: String?
     let signing: iOSSigning?
@@ -158,6 +161,7 @@ struct UnnamediOSVariant: Codable {
         case versionName = "version_name"
         case versionNumber = "version_number"
         case appIcon = "app_icon"
+        case appName = "app_name"
         case idSuffix = "id_suffix"
         case bundleID = "bundle_id"
         case signing
@@ -172,6 +176,7 @@ extension UnnamediOSVariant {
         versionName = try values.decodeOrReadFromEnv(String.self, forKey: .versionName)
         versionNumber = try values.decodeOrReadFromEnv(Int.self, forKey: .versionNumber)
         appIcon = try values.decodeIfPresentOrReadFromEnv(String.self, forKey: .appIcon)
+        appName = try values.decodeIfPresentOrReadFromEnv(String.self, forKey: .appName)
         idSuffix = try values.decodeIfPresentOrReadFromEnv(String.self, forKey: .idSuffix)
         bundleID = try values.decodeIfPresentOrReadFromEnv(String.self, forKey: .bundleID)
         signing = try values.decodeIfPresent(iOSSigning.self, forKey: .signing)
@@ -187,6 +192,7 @@ extension iOSVariant {
             versionName: unnamediOSVariant.versionName,
             versionNumber: unnamediOSVariant.versionNumber,
             appIcon: unnamediOSVariant.appIcon,
+            appName: unnamediOSVariant.appName,
             storeDestination: unnamediOSVariant.storeDestination,
             custom: unnamediOSVariant.custom,
             idSuffix: unnamediOSVariant.idSuffix,

--- a/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
+++ b/Tests/VariantsCoreTests/FastlaneParametersFactoryTests.swift
@@ -128,6 +128,7 @@ class FastlaneParametersFactoryTests: XCTestCase {
             versionName: "2.3.4",
             versionNumber: 99,
             appIcon: nil,
+            appName: nil,
             storeDestination: "testFlight",
             custom: nil,
             idSuffix: "sample",

--- a/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
+++ b/Tests/VariantsCoreTests/VariantsFileFactoryTests.swift
@@ -35,6 +35,7 @@ class VariantsFileFactoryTests: XCTestCase {
         versionName: "2.3.4",
         versionNumber: 99,
         appIcon: nil,
+        appName: nil,
         storeDestination: "testFlight",
         custom: [CustomProperty(name: "PROPERTY_A", value: "VALUE_A", destination: .project),
                  CustomProperty(name: "PROPERTY_B", value: "VALUE_B", env: true, destination: .project)],

--- a/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
+++ b/Tests/VariantsCoreTests/XcodeProjFactoryTests.swift
@@ -36,7 +36,7 @@ class XcodeProjFactoryTests: XCTestCase {
         let proj = XCConfigFactory(logger: Logger(verbose: true))
         let target = iOSTarget(name: "", app_icon: "", bundleId: "", testTarget: "",
                                source: .init(path: "", info: "", config: ""))
-        guard let variant = try? iOSVariant(name: target.name, versionName: "", versionNumber: 0, appIcon: nil,
+        guard let variant = try? iOSVariant(name: target.name, versionName: "", versionNumber: 0, appIcon: nil, appName: nil,
                                             storeDestination: nil, custom: nil, idSuffix: "", bundleID: nil, variantSigning: nil,
                                             globalSigning: iOSSigning(teamName: "", teamID: "", exportMethod: .appstore, matchURL: ""))
         else {

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -20,7 +20,7 @@ class iOSVariantTests: XCTestCase {
     // MARK: - Initializer tests
     func testiOSVariantInitWithUnnamediOSVariant() {
         let customProperties = [CustomProperty(name: "Name", value: "Value", destination: .project)]
-        let unnamedVariant = UnnamediOSVariant(versionName: "1.0", versionNumber: 0, appIcon: "app_icon", idSuffix: "beta", bundleID: nil,
+        let unnamedVariant = UnnamediOSVariant(versionName: "1.0", versionNumber: 0, appIcon: "app_icon", appName: nil, idSuffix: "beta", bundleID: nil,
                                                signing: validSigning, custom: customProperties, storeDestination: "testflight")
         
         func makeiOSVariant() throws -> iOSVariant {
@@ -42,7 +42,7 @@ class iOSVariantTests: XCTestCase {
     // MARK: - Default property assigning
     func testInitNilFallbackToDefaultProperties() {
         func makeiOSVariant() throws -> iOSVariant {
-            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: nil, custom: nil,
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: nil, custom: nil,
                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         }
         
@@ -55,7 +55,7 @@ class iOSVariantTests: XCTestCase {
     // MARK: - Computed properties
     func testGetTitle() {
         let name = "Variant Name"
-        guard let variant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let variant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -65,7 +65,7 @@ class iOSVariantTests: XCTestCase {
     
     func testGetConfigName() {
         // Default variant
-        guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                                    idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -74,7 +74,7 @@ class iOSVariantTests: XCTestCase {
         
         // Any variant
         let name = "Variant Name"
-        guard let anyVariant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let anyVariant = try? iOSVariant(name: name, versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                                idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -84,7 +84,7 @@ class iOSVariantTests: XCTestCase {
     
     func testGetDestinationProperty() {
         let targetDestination = iOSVariant.Destination.appCenter
-        guard let variant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: targetDestination.rawValue,
+        guard let variant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: targetDestination.rawValue,
                                             custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -106,6 +106,7 @@ class iOSVariantTests: XCTestCase {
             versionName: "1.0.0",
             versionNumber: 0,
             appIcon: nil,
+            appName: nil,
             storeDestination: "appStore",
             custom: nil,
             idSuffix: "beta",
@@ -119,6 +120,7 @@ class iOSVariantTests: XCTestCase {
             versionName: "1.0.0",
             versionNumber: 0,
             appIcon: nil,
+            appName: nil,
             storeDestination: "appStore",
             custom: nil,
             idSuffix: nil,
@@ -136,7 +138,7 @@ class iOSVariantTests: XCTestCase {
         )
         
         func makeiOSVariant() throws -> iOSVariant {
-            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                            idSuffix: "beta", bundleID: "com.company.customBundle", variantSigning: nil, globalSigning: validSigning)
         }
         
@@ -154,7 +156,7 @@ class iOSVariantTests: XCTestCase {
         )
         
         func makeiOSVariant() throws -> iOSVariant {
-            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                            idSuffix: nil, bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         }
         
@@ -165,7 +167,7 @@ class iOSVariantTests: XCTestCase {
     
     func testMakeBundleIDForVariant() {
         // ID Suffix provided
-        guard let idSuffixVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let idSuffixVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                                     idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -173,7 +175,7 @@ class iOSVariantTests: XCTestCase {
         XCTAssertEqual(idSuffixVariant.makeBundleID(for: target), "com.Company.ValidName.beta")
                 
         // Bundle ID provided
-        guard let bundleIDVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let bundleIDVariant = try? iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                                     idSuffix: nil, bundleID: "com.Overwritten.BundleID", variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -181,7 +183,7 @@ class iOSVariantTests: XCTestCase {
         XCTAssertEqual(bundleIDVariant.makeBundleID(for: target), "com.Overwritten.BundleID")
         
         // Default variant
-        guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let defaultVariant = try? iOSVariant(name: "default", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                                    idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -198,6 +200,7 @@ class iOSVariantTests: XCTestCase {
             versionName: "1.0.0",
             versionNumber: 0,
             appIcon: nil,
+            appName: nil,
             storeDestination: "appStore",
             custom: nil,
             idSuffix: "beta",
@@ -211,6 +214,7 @@ class iOSVariantTests: XCTestCase {
             versionName: "1.0.0",
             versionNumber: 0,
             appIcon: nil,
+            appName: nil,
             storeDestination: "appStore",
             custom: nil,
             idSuffix: "beta",
@@ -224,6 +228,7 @@ class iOSVariantTests: XCTestCase {
             versionName: "1.0.0",
             versionNumber: 0,
             appIcon: nil,
+            appName: nil,
             storeDestination: "appStore",
             custom: nil,
             idSuffix: "beta",
@@ -241,7 +246,7 @@ class iOSVariantTests: XCTestCase {
         )
         
         func makeiOSVariant() throws -> iOSVariant {
-            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+            try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: nil)
         }
         
@@ -259,7 +264,28 @@ class iOSVariantTests: XCTestCase {
             (key: "V_VERSION_NUMBER", value: "0")
         ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
-        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
+                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
+        else {
+            return XCTFail("Failed to initialize iOSVariant with provided parameters")
+        }
+        let defaultValues = variant.getDefaultValues(for: target)
+        XCTAssertEqual(defaultValues.count, expectedValues.count)
+        defaultValues.enumerated().forEach({
+            XCTAssertEqual($1.key, expectedValues[$0].key)
+        })
+    }
+    
+    func testGetDefaultValuesForTargetWithCustomAppName() {
+        let expectedValues: [(key: String, value: String)] = [
+            (key: "V_APP_ICON", value: "AppIcon"),
+            (key: "V_APP_NAME", value: "App Marketing Name"),
+            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
+            (key: "V_VERSION_NAME", value: "1.0.0"),
+            (key: "V_VERSION_NUMBER", value: "0")
+        ]
+        let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: "App Marketing Name",  storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -280,7 +306,7 @@ class iOSVariantTests: XCTestCase {
             (key: "V_VERSION_NAME", value: "1.0.0"),
             (key: "V_VERSION_NUMBER", value: "0")
         ]
-        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -307,7 +333,7 @@ class iOSVariantTests: XCTestCase {
             CustomProperty(name: "Custom name", value: "Custom value", env: false, destination: .project),
             CustomProperty(name: "Custom name 2", value: "Custom value 2", env: true, destination: .project),
             CustomProperty(name: "Custom name 3", value: "Custom value 3", env: false, destination: .fastlane)]
-        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore",
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore",
                                             custom: customProperties, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")
@@ -325,7 +351,7 @@ class iOSVariantTests: XCTestCase {
     // MARK: - iOSVariants.Destination tests
     func testParsingiOSVariantDestintation() {
         func makeVariant(destination: String?) throws -> iOSVariant {
-            try iOSVariant(name: "Variant Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: destination,
+            try iOSVariant(name: "Variant Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: destination,
                            custom: nil, idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
         }
         
@@ -360,6 +386,7 @@ class iOSVariantTests: XCTestCase {
         ("testInitWithValidSigningConfiguration", testInitWithValidSigningConfiguration),
         ("testInitWithoutSigningConfiguration", testInitWithoutSigningConfiguration),
         ("testGetDefaultValuesForTargetWithoutSigning", testGetDefaultValuesForTargetWithoutSigning),
+        ("testGetDefaultValuesForTargetWithCustomAppName", testGetDefaultValuesForTargetWithCustomAppName),
         ("testGetDefaultValuesForTargetWithSigning", testGetDefaultValuesForTargetWithSigning),
         ("testGetDefaultValuesWithTargetAndCustomProperties", testGetDefaultValuesWithTargetAndCustomProperties),
         ("testParsingiOSVariantDestintation", testParsingiOSVariantDestintation)

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -256,12 +256,12 @@ class iOSVariantTests: XCTestCase {
     }
     
     func testGetDefaultValuesForTargetWithoutSigning() {
-        let expectedValues: [(key: String, value: String)] = [
-            (key: "V_APP_ICON", value: "AppIcon"),
-            (key: "V_APP_NAME", value: "Target Name Beta"),
-            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
-            (key: "V_VERSION_NAME", value: "1.0.0"),
-            (key: "V_VERSION_NUMBER", value: "0")
+        let expectedValues: [String: String] = [
+            "V_APP_ICON": "AppIcon",
+            "V_APP_NAME": "Target Name Beta",
+            "V_BUNDLE_ID": "com.Company.ValidName.beta",
+            "V_VERSION_NAME": "1.0.0",
+            "V_VERSION_NUMBER": "0"
         ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
@@ -271,18 +271,18 @@ class iOSVariantTests: XCTestCase {
         }
         let defaultValues = variant.getDefaultValues(for: target)
         XCTAssertEqual(defaultValues.count, expectedValues.count)
-        defaultValues.enumerated().forEach({
-            XCTAssertEqual($1.key, expectedValues[$0].key)
+        defaultValues.forEach({
+            XCTAssertEqual($0.value, expectedValues[$0.key])
         })
     }
     
     func testGetDefaultValuesForTargetWithCustomAppName() {
-        let expectedValues: [(key: String, value: String)] = [
-            (key: "V_APP_ICON", value: "AppIcon"),
-            (key: "V_APP_NAME", value: "App Marketing Name"),
-            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
-            (key: "V_VERSION_NAME", value: "1.0.0"),
-            (key: "V_VERSION_NUMBER", value: "0")
+        let expectedValues: [String: String] = [
+            "V_APP_ICON": "AppIcon",
+            "V_APP_NAME": "App Marketing Name",
+            "V_BUNDLE_ID": "com.Company.ValidName.beta",
+            "V_VERSION_NAME": "1.0.0",
+            "V_VERSION_NUMBER": "0"
         ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil,
@@ -293,19 +293,41 @@ class iOSVariantTests: XCTestCase {
         }
         let defaultValues = variant.getDefaultValues(for: target)
         XCTAssertEqual(defaultValues.count, expectedValues.count)
-        defaultValues.enumerated().forEach({
-            XCTAssertEqual($1.key, expectedValues[$0].key)
+        defaultValues.forEach({
+            XCTAssertEqual($0.value, expectedValues[$0.key])
+        })
+    }
+    
+    func testGetDefaultValuesForTargetWithoutCustomAppName() {
+        let expectedValues: [String: String] = [
+            "V_APP_ICON": "AppIcon",
+            "V_APP_NAME": "Target Name Beta",
+            "V_BUNDLE_ID": "com.Company.ValidName.beta",
+            "V_VERSION_NAME": "1.0.0",
+            "V_VERSION_NUMBER": "0"
+        ]
+        let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil,
+                                            appName: nil, storeDestination: "appStore", custom: nil,
+                                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
+        else {
+            return XCTFail("Failed to initialize iOSVariant with provided parameters")
+        }
+        let defaultValues = variant.getDefaultValues(for: target)
+        XCTAssertEqual(defaultValues.count, expectedValues.count)
+        defaultValues.forEach({
+            XCTAssertEqual($0.value, expectedValues[$0.key])
         })
     }
     
     func testGetDefaultValuesForTargetWithSigning() {
-        let expectedValues = [
-            (key: "V_APP_ICON", value: "AppIcon"),
-            (key: "V_APP_NAME", value: "Target Name Beta"),
-            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
-            (key: "V_MATCH_PROFILE", value: "match AppStore com.Company.ValidName.beta"),
-            (key: "V_VERSION_NAME", value: "1.0.0"),
-            (key: "V_VERSION_NUMBER", value: "0")
+        let expectedValues: [String: String] = [
+            "V_APP_ICON": "AppIcon",
+            "V_APP_NAME": "Target Name Beta",
+            "V_BUNDLE_ID": "com.Company.ValidName.beta",
+            "V_MATCH_PROFILE": "match AppStore com.Company.ValidName.beta",
+            "V_VERSION_NAME": "1.0.0",
+            "V_VERSION_NUMBER": "0"
         ]
         guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: nil, storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: validSigning)
@@ -315,20 +337,20 @@ class iOSVariantTests: XCTestCase {
 
         let defaultValues = variant.getDefaultValues(for: target)
         XCTAssertEqual(defaultValues.count, expectedValues.count)
-        defaultValues.enumerated().forEach({
-            XCTAssertEqual($1.key, expectedValues[$0].key)
+        defaultValues.forEach({
+            XCTAssertEqual($0.value, expectedValues[$0.key])
         })
     }
     
     func testGetDefaultValuesWithTargetAndCustomProperties() {
-        let expectedValues = [
-            (key: "Custom name", value: "Custom value"),
-            (key: "V_APP_ICON", value: "AppIcon"),
-            (key: "V_APP_NAME", value: "Target Name Beta"),
-            (key: "V_BUNDLE_ID", value: "com.Company.ValidName.beta"),
-            (key: "V_MATCH_PROFILE", value: "match AppStore com.Company.ValidName.beta"),
-            (key: "V_VERSION_NAME", value: "1.0.0"),
-            (key: "V_VERSION_NUMBER", value: "0")
+        let expectedValues: [String: String] = [
+            "Custom name": "Custom value",
+            "V_APP_ICON": "AppIcon",
+            "V_APP_NAME": "Target Name Beta",
+            "V_BUNDLE_ID": "com.Company.ValidName.beta",
+            "V_MATCH_PROFILE": "match AppStore com.Company.ValidName.beta",
+            "V_VERSION_NAME": "1.0.0",
+            "V_VERSION_NUMBER": "0"
         ]
         let customProperties = [
             CustomProperty(name: "Custom name", value: "Custom value", env: false, destination: .project),
@@ -342,8 +364,8 @@ class iOSVariantTests: XCTestCase {
 
         let defaultValues = variant.getDefaultValues(for: target)
         XCTAssertEqual(defaultValues.count, expectedValues.count)
-        defaultValues.enumerated().forEach({
-            XCTAssertEqual($1.key, expectedValues[$0].key)
+        defaultValues.forEach({
+            XCTAssertEqual($0.value, expectedValues[$0.key])
         })
         XCTAssertFalse(defaultValues.contains(where: {$0.key == "Custom name 2"}), "Should not contains this property as it's an environment variable")
         XCTAssertFalse(defaultValues.contains(where: {$0.key == "Custom name 3"}), "Should not contains this property as it's not a project destination property")
@@ -388,6 +410,7 @@ class iOSVariantTests: XCTestCase {
         ("testInitWithoutSigningConfiguration", testInitWithoutSigningConfiguration),
         ("testGetDefaultValuesForTargetWithoutSigning", testGetDefaultValuesForTargetWithoutSigning),
         ("testGetDefaultValuesForTargetWithCustomAppName", testGetDefaultValuesForTargetWithCustomAppName),
+        ("testGetDefaultValuesForTargetWithoutCustomAppName", testGetDefaultValuesForTargetWithoutCustomAppName),
         ("testGetDefaultValuesForTargetWithSigning", testGetDefaultValuesForTargetWithSigning),
         ("testGetDefaultValuesWithTargetAndCustomProperties", testGetDefaultValuesWithTargetAndCustomProperties),
         ("testParsingiOSVariantDestintation", testParsingiOSVariantDestintation)

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -285,7 +285,8 @@ class iOSVariantTests: XCTestCase {
             (key: "V_VERSION_NUMBER", value: "0")
         ]
         let signing = iOSSigning(teamName: "Signing Team Name", teamID: "AB12345CD", exportMethod: .appstore, matchURL: nil)
-        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil, appName: "App Marketing Name",  storeDestination: "appStore", custom: nil,
+        guard let variant = try? iOSVariant(name: "Beta", versionName: "1.0.0", versionNumber: 0, appIcon: nil,
+                                            appName: "App Marketing Name", storeDestination: "appStore", custom: nil,
                                             idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: signing)
         else {
             return XCTFail("Failed to initialize iOSVariant with provided parameters")

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,8 @@ ios:
         version_name: 0.0.1
         version_number: {{ envVars.VERSION_CODE }}
         store_destination: AppStore
+        # This is an optional field to override the default app name per variant
+        app_name: App Marketing Name 
         custom:
             - name: apiBaseUrl
               value: https://sample.com/


### PR DESCRIPTION
### What does this PR do
- Enable the ability to override the default name for each variant

### How can it be tested
1 . Add the `app_name` field  to `samples/ios/VariantsTestApp/variants.yml` to either the `default` or `beta` variant
2. cd `samples/ios/VariantsTestApp/` 
3. switch to this variant: `swift run variants switch --variant <variant>`
4. you should notice in `samples/ios/VariantsTestApp/VariantsTestApp/Variants/variants.xcconfig` that the `V_APP_NAME` is equal to the value that you had previously set for `app_name`

### Task
resolved https://github.com/Backbase/variants/issues/216

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
