### PR TITLE
fix/signing-config-setup

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -31,13 +31,20 @@ var bigPRThreshold = 500
 
 let swiftFilesWithoutCopyright = changedFiles.filter {
     $0.fileType == .swift
-        && !danger.utils.readFile($0).contains(
-            """
-            //
-            //  Variants
-            //
-            //  Copyright (c) Backbase B.V. - https://www.backbase.com
-            """)
+        && (
+            !danger.utils.readFile($0).contains(
+                """
+                //
+                //  Variants
+                """
+            )
+
+            || !danger.utils.readFile($0).contains(
+                """
+                //  Copyright (c) Backbase B.V. - https://www.backbase.com
+                """
+            )
+        )
 }
 
 if swiftFilesWithoutCopyright.count > 0 {

--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -177,7 +177,6 @@ class XCConfigFactory: XCFactory {
         projectPath: Path
     ) {
         guard
-            variant.signing?.matchURL != nil,
             let exportMethod = variant.signing?.exportMethod,
             let teamName = variant.signing?.teamName,
             let teamID = variant.signing?.teamID

--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -58,7 +58,6 @@ class XCConfigFactory: XCFactory {
             try encodedJSONString.write(toFile: file.absolute().description, atomically: true, encoding: .utf8)
             
             return (true, file)
-            
         } catch {
             return (false, nil)
         }
@@ -76,7 +75,6 @@ class XCConfigFactory: XCFactory {
             throw RuntimeError("Attempting to create \(xcconfigFileName) - Path to Xcode Project not found")
         }
         let xcodeProjPath = Path(xcodeProj)
-        
         let configString = target.value.source.config
         
         logger.logInfo("Checking if \(xcconfigFileName) exists", item: "")
@@ -93,7 +91,6 @@ class XCConfigFactory: XCFactory {
         
         _ = write("", toFile: xcodeConfigPath, force: true)
         logger.logInfo("Created file: ", item: "'\(xcconfigFileName)' at \(xcodeConfigPath.parent().abbreviate().description)")
-        
         populateConfig(with: target, configFile: xcodeConfigPath, variant: variant)
 
         /*
@@ -113,7 +110,6 @@ class XCConfigFactory: XCFactory {
          */
         let infoPath = target.value.source.info
         let infoPlistPath = Path("\(configPath)/\(infoPath)")
-        
         updateInfoPlist(with: target.value, configFile: infoPlistPath, variant: variant)
         
         /*
@@ -132,7 +128,6 @@ class XCConfigFactory: XCFactory {
                             target: NamedTarget,
                             variant: iOSVariant) {
         let variantsFile = Path("\(xcConfigFile.parent().absolute().description)/Variants.swift")
-
         do {
             let path = try TemplateDirectory().path
             try Bash("cp", arguments:
@@ -157,7 +152,6 @@ class XCConfigFactory: XCFactory {
                 in: projectPath,
                 target: target.value,
                 asTestSettings: true)
-            
         } catch {
             logger.logError("❌ ", item: "Failed to add Variants.swift to Xcode Project")
         }
@@ -204,7 +198,6 @@ class XCConfigFactory: XCFactory {
     
     private func importPodsIfNeeded(target: NamedTarget, configFile: Path) {
         guard StaticPath.Pod.podFileFile.exists else { return }
-        
         // this regex finds a folder that starts with Pods and ends with the target key, with a ".release.xcconfig" extension.
         let podConfigFileRegex: String = "./Pods/Target Support Files/Pods.*-\(target.key)/.*\\.release\\.xcconfig"
         guard let podsConfigFile: String = try? Bash("find | head -n 1", arguments: ".", "-regex", podConfigFileRegex).capture(),
@@ -212,7 +205,6 @@ class XCConfigFactory: XCFactory {
             logger.logError("❌ ", item: "Failed to import Pods config in .xcconfig, Pod config file not found")
             return
         }
-        
         let includeStatement = "#include \"\(podsConfigFile)\""
         let (success, _) = write(includeStatement, toFile: configFile, force: false)
         if !success {
@@ -221,7 +213,6 @@ class XCConfigFactory: XCFactory {
     }
     
     private func updateInfoPlist(with target: iOSTarget, configFile: Path, variant: iOSVariant) {
-        
         let configFilePath = configFile.absolute().description
         do {
             // TODO: Add plutil as separate command?

--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -179,7 +179,9 @@ class XCConfigFactory: XCFactory {
         guard
             let exportMethod = variant.signing?.exportMethod,
             let teamName = variant.signing?.teamName,
-            let teamID = variant.signing?.teamID
+            let teamID = variant.signing?.teamID,
+            !teamID.isEmpty,
+            !teamName.isEmpty
         else { return }
 
         let xcodeFactory = XcodeProjFactory()

--- a/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XCConfigFactory.swift
@@ -176,23 +176,23 @@ class XCConfigFactory: XCFactory {
         inTarget target: NamedTarget,
         projectPath: Path
     ) {
-        let xcodeFactory = XcodeProjFactory()
-        var mainTargetSettings = [String: String]()
-        if
+        guard
             variant.signing?.matchURL != nil,
             let exportMethod = variant.signing?.exportMethod,
             let teamName = variant.signing?.teamName,
-            let teamID = variant.signing?.teamID {
+            let teamID = variant.signing?.teamID
+        else { return }
 
-            var certType = "Development"
-            if exportMethod == .appstore || exportMethod == .enterprise {
-                certType = "Distribution"
-            }
-
-            mainTargetSettings["PROVISIONING_PROFILE_SPECIFIER"] = "$(V_MATCH_PROFILE)"
-            mainTargetSettings["CODE_SIGN_STYLE"] = "Manual"
-            mainTargetSettings["CODE_SIGN_IDENTITY"] = "Apple \(certType): \(teamName) (\(teamID))"
+        let xcodeFactory = XcodeProjFactory()
+        var certType = "Development"
+        if exportMethod == .appstore || exportMethod == .enterprise {
+            certType = "Distribution"
         }
+        let mainTargetSettings = [
+            "PROVISIONING_PROFILE_SPECIFIER": "$(V_MATCH_PROFILE)",
+            "CODE_SIGN_STYLE": "Manual",
+            "CODE_SIGN_IDENTITY": "Apple \(certType): \(teamName) (\(teamID))"
+        ]
         xcodeFactory.modify(mainTargetSettings, in: projectPath, target: target.value)
     }
     

--- a/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
@@ -125,8 +125,7 @@ struct XcodeProjFactory {
             }
             try project.write(path: projectPath)
         } catch {
-            dump(error)
-            logger.logFatal("❌ ", item: "Unable to add files to Xcode project '\(projectPath)'")
+            logger.logFatal("❌ ", item: "Unable to add files to Xcode project '\(projectPath)', error: '\(error.localizedDescription)'")
         }
     }
     

--- a/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
+++ b/Sources/VariantsCore/Schemas/iOS/iOSVariant.swift
@@ -101,11 +101,12 @@ public struct iOSVariant: Variant {
         } else if let globalSigning = globalSigning {
             return try globalSigning ~ nil
         } else {
-            throw RuntimeError(
+            Logger.shared.logWarning(item:
                 """
                 Variant "\(name)" doesn't contain a 'signing' configuration. \
                 Create a global 'signing' configuration or make sure all variants have this property.
                 """)
+            return nil
         }
     }
     

--- a/Tests/VariantsCoreTests/Resources/ios/invalid_incomplete_signing_configuration.yml
+++ b/Tests/VariantsCoreTests/Resources/ios/invalid_incomplete_signing_configuration.yml
@@ -58,6 +58,6 @@ ios:
           destination: project
 
     signing:
-      match_url: "git@github.com:backbase-rnd/cs-mobile-ios-match.git"
+      match_url: "git@github.com:sample/sample-match-repo.git"
       team_name: "Backbase B.V."
-      team_id: "R22WT7DX79"
+      team_id: "ABC247DXU9"

--- a/Tests/VariantsCoreTests/Resources/ios/invalid_incomplete_signing_configuration.yml
+++ b/Tests/VariantsCoreTests/Resources/ios/invalid_incomplete_signing_configuration.yml
@@ -56,3 +56,8 @@ ios:
         - name: SAMPLE_GLOBAL
           value: GLOBAL Value iOS
           destination: project
+
+    signing:
+      match_url: "git@github.com:backbase-rnd/cs-mobile-ios-match.git"
+      team_name: "Backbase B.V."
+      team_id: "R22WT7DX79"

--- a/Tests/VariantsCoreTests/YamlParserTests.swift
+++ b/Tests/VariantsCoreTests/YamlParserTests.swift
@@ -49,11 +49,12 @@ class YamlParserTests: XCTestCase {
         }
     }
     
-    func testExtractConfiguration_invalid_iOS_missingSigningConfiguration() {
+    func testExtractConfiguration_invalid_iOS_incompleteSigningConfiguration() {
         let expectedUnderlyingError = RuntimeError(
             """
-            Variant "BETA" doesn't contain a 'signing' configuration. \
-            Create a global 'signing' configuration or make sure all variants have this property.
+            Missing: 'signing.export_method'
+            At least one variant doesn't contain 'signing.export_method' in its configuration.
+            Create a global 'signing' configuration with 'export_method' or make sure all variants have this property.
             """
         )
         
@@ -280,8 +281,8 @@ class YamlParserTests: XCTestCase {
          testExtractConfiguration_invalidSpec),
         ("testExtractConfiguration_invalid_iOS_missingExportMethod",
          testExtractConfiguration_invalid_iOS_missingExportMethod),
-        ("testExtractConfiguration_invalid_iOS_missingSigningConfiguration",
-         testExtractConfiguration_invalid_iOS_missingSigningConfiguration),
+        ("testExtractConfiguration_invalid_iOS_incompleteSigningConfiguration",
+         testExtractConfiguration_invalid_iOS_incompleteSigningConfiguration),
         ("testExtractConfiguration_valid_iOS",
          testExtractConfiguration_valid_iOS),
         ("testExtractConfiguration_valid_android",

--- a/Tests/VariantsCoreTests/iOSVariantTests.swift
+++ b/Tests/VariantsCoreTests/iOSVariantTests.swift
@@ -233,21 +233,12 @@ class iOSVariantTests: XCTestCase {
     }
     
     func testInitWithoutSigningConfiguration() {
-        let expectedError = RuntimeError(
-            """
-            Variant "Valid Name" doesn't contain a 'signing' configuration. \
-            Create a global 'signing' configuration or make sure all variants have this property.
-            """
-        )
-        
         func makeiOSVariant() throws -> iOSVariant {
             try iOSVariant(name: "Valid Name", versionName: "1.0.0", versionNumber: 0, appIcon: nil, storeDestination: "appStore", custom: nil,
                            idSuffix: "beta", bundleID: nil, variantSigning: nil, globalSigning: nil)
         }
-        
-        XCTAssertThrowsError(try makeiOSVariant(), "At least one signing needs to be provided") { error in
-            XCTAssertEqual(error as? RuntimeError, expectedError)
-        }
+
+        XCTAssertNoThrow(try makeiOSVariant())
     }
     
     func testGetDefaultValuesForTargetWithoutSigning() {


### PR DESCRIPTION
### What does this PR do
- Removes the runtime error when `signing` configuration is `nil` and, instead, maintains the project's signing settings as is (i.e.: in case of automatic signing)
- Adds/adjusts signing configuration when switching variants, not only during setup.
- When adding/adjusting signing configuration also include `CODE_SIGN_STYLE` and `CODE_SIGN_IDENTITY`
- Makes `updateSigningConfig` an optional step.
- Removes the necessity to have a `matchURL` parameter in the signing configuration, thus enabling locally installed provisioning profiles and certs

### How can it be tested
1. Setup a new project using a `variants.yml` without a `signing` configuration. This should no longer fail. Instead, it should setup everything but maintain the existing signing config in Xcode.
2. Add a signing configuration to your `variants.yml` (either global or variant's specific) and switch variants. This should now modify the project's signing config in Xcode.

### Task
resolves #214
resolves #215 

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
