### PR TITLE
Reverting supporting-variants-and-pods-configs-simultaneously

### DIFF
--- a/Sources/VariantsCore/Helpers/Constants.swift
+++ b/Sources/VariantsCore/Helpers/Constants.swift
@@ -30,10 +30,6 @@ struct StaticPath {
         static let variantsFileName = "Variants.swift"
     }
     
-    struct Pod {
-        static let podFileFile = Path("Podfile")
-    }
-    
     struct Template {
         static let variantsScriptFileName = "variants-template.gradle"
         static let fastlaneParametersFileName = "variants_params_template.rb"


### PR DESCRIPTION
reverted changes to fix bug which caused the UITests project to import an unneeded pod used by the app project, since the xcconfig is shared between the app and the tests projects

### What does this PR do
-

### How can it be tested
Tell us how to test these changes

### Task
resolves #X (where `#X` is the number of an issue)

### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
