### PR TITLE
chore: version bump to 1.2.1

### DIFF
--- a/Sources/Variants/main.swift
+++ b/Sources/Variants/main.swift
@@ -12,7 +12,7 @@ struct Variants: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "variants",
         abstract: "A command-line tool to setup deployment variants and working CI/CD setup",
-        version: "1.2.0",
+        version: "1.2.1",
         subcommands: [
             Initializer.self,
             Setup.self,

--- a/docs/GITHUB_ACTION.md
+++ b/docs/GITHUB_ACTION.md
@@ -11,7 +11,7 @@ If Github Actions is your CI and you use the [Github-hosted macOS runner](https:
 ```yaml
 - uses: backbase/variants@main
   with:
-    version: 1.2.0
+    version: 1.2.1
     spec: variants.yml
     platform: ios
     variant: beta


### PR DESCRIPTION
### What does this PR do
- Bump version to 1.2.1
- 
### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
