### PR TITLE
Update xcconfig in the main target only if using cocoapods

### DIFF
--- a/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
+++ b/Sources/VariantsCore/Factory/iOS/XcodeProjFactory.swift
@@ -5,6 +5,8 @@
 //  Created by Arthur Alves
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import XcodeProj
 import PathKit
@@ -163,6 +165,7 @@ struct XcodeProjFactory {
 
     private func isCocoapodsWorkspace(configurations: [XCBuildConfiguration]) -> Bool {
         for conf in configurations {
+            // swiftlint:disable:next for_where
             if conf.baseConfiguration?.name?.lowercased().contains("pods") == true {
                 return true
             }
@@ -268,3 +271,5 @@ private extension XCBuildConfiguration {
         buildSettings["INFO_PLIST"] as? String
     }
 }
+
+// swiftlint:enable file_length


### PR DESCRIPTION
### What does this PR do
Detects if user is using Cocoapods and, in that case, only set the xcconfig to the main build configurations to not break the Cocoapods' generate xcconfig file.

### How can it be tested
The variants' commands should work in a project with or without Cocoapods. It should be tested in samples on both cases.

### Task


### Checklist:

- [x] I ran `make validation` locally with success
- [x] I have not introduced new bugs
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
